### PR TITLE
Fix travis issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ apt_packages:
   - libgsl0-dbg
   - libgsl0-dev
   - libgsl0ldbl
+  - libgsl2
   - libboost-all-dev
   - libnlopt-dev
   - libeigen3-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ warnings_are_errors: false
 
 apt_packages:
   - gsl-bin
-  - libgsl0-dbg
-  - libgsl0-dev
+  - libgsl-dbg
+  - libgsl-dev
   - libgsl2
   - libboost-all-dev
   - libnlopt-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ apt_packages:
   - libcurl4-openssl-dev
   - libxml2-dev
   - r-cran-vinecopula
+  - r-cran-copula
   - r-cran-nloptr
   - r-cran-rcpp
   - r-cran-rcppeigen

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,15 @@ warnings_are_errors: false
 
 
 apt_packages:
-  - libgsl-dbg
-  - libgsl-dev
-  - libgsl2
+  - libgsl0-dbg
+  - libgsl0-dev
+  - libgsl0ldbl
   - libboost-all-dev
   - libnlopt-dev
   - libeigen3-dev
   - libcurl4-openssl-dev
   - libxml2-dev
   - r-cran-vinecopula
-  - r-cran-copula
-  - r-cran-gsl
   - r-cran-nloptr
   - r-cran-rcpp
   - r-cran-rcppeigen

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ apt_packages:
   - libxml2-dev
   - r-cran-vinecopula
   - r-cran-copula
+  - r-cran-gsl
   - r-cran-nloptr
   - r-cran-rcpp
   - r-cran-rcppeigen

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ apt_packages:
   - gsl-bin
   - libgsl0-dbg
   - libgsl0-dev
-  - libgsl0ldbl
   - libgsl2
   - libboost-all-dev
   - libnlopt-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ warnings_are_errors: false
 
 
 apt_packages:
-  - gsl-bin
   - libgsl-dbg
   - libgsl-dev
   - libgsl2


### PR DESCRIPTION
Travis suddenly caused problems with gsl (same for other packages). I fixed it by removing `gsl-bin` which seems not to be required.