### PR TITLE
Remove openmp from Makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,6 +1,6 @@
 CXX_STD      = CXX11
 PKG_CPPFLAGS = -I../inst/include -I"$(NLOPT_HOME)$(R_ARCH)/include"
-PKG_LIBS     = -L"$(NLOPT_HOME)$(R_ARCH)/lib" -lnlopt  $(SHLIB_OPENMP_CFLAGS)
+PKG_LIBS     = -L"$(NLOPT_HOME)$(R_ARCH)/lib" -lnlopt  
 
 SOURCES_CPP = ./bicop/abstract.cpp	  ./bicop/bb7.cpp      ./bicop/elliptical.cpp  ./bicop/gumbel.cpp  ./bicop/parametric.cpp \
               ./bicop/archimedean.cpp ./bicop/bb8.cpp      ./bicop/family.cpp      ./bicop/indep.cpp   ./bicop/student.cpp \


### PR DESCRIPTION
Since 

1. we are currently not using it, 
2. and it is not supported by OS X's default compiler,

I suggest that we remove it for now.