### PR TITLE
Remove nloptr import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,7 @@ License: GPL-3 | file LICENSE
 Encoding: UTF-8
 LazyData: true
 Imports:
-    Rcpp,
-    nloptr
+    Rcpp
 Suggests:
     testthat,
     VineCopula


### PR DESCRIPTION
Currently, the nlptr import is only used for the NLOPT_HOME variable to point to the local install of nlopt. Furthermore, this hack is not portable (i.e., does not work in OS X and windows).

Therefore, while we wait for nloptr to ship the headers along with the shared object provided with CRAN's binaries (see https://github.com/jyypma/nloptr/issues/27), I think that the dependency is superfluous.

An alternative solution would be to ship the headers ourselves and use the shared object provided with CRAN's binaries.