### PR TITLE
Revert stripping the lib

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -13,9 +13,3 @@ SOURCES_CPP = ./bicop/abstract.cpp	  ./bicop/bb7.cpp      ./bicop/elliptical.cpp
 SOURCES_C   = ./misc/tools_c.c
 
 OBJECTS = $(SOURCES_CPP:.cpp=.o) $(SOURCES_C:.c=.o)
-
-strippedLib: $(SHLIB)
-	if test -e "/usr/bin/strip"; then /usr/bin/strip --strip-debug $(SHLIB); fi
-
-.phony: strippedLib
-


### PR DESCRIPTION
1. It does not work on OSX
2. It is untested on Windows

=> While 1. and 2. are not resolved, I am in favor to remove the stripping.