### PR TITLE
Prepare 0.1.0.1.0

### DIFF
--- a/R/rvinecopulib.R
+++ b/R/rvinecopulib.R
@@ -11,7 +11,7 @@
 #' @docType package
 #' @useDynLib rvinecopulib, .registration = TRUE
 #' @importFrom Rcpp evalCpp
-#'
+#' 
 #' @author Thomas Nagler, Thibault Vatter
 #
 #' @keywords package

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -10,6 +10,6 @@ SOURCES_CPP = ./bicop/abstract.cpp	  ./bicop/bb7.cpp      ./bicop/elliptical.cpp
               ./misc/tools_integration.cpp  ./misc/tools_stats.cpp \
               ./vinecop/class.cpp  ./vinecop/rvine_matrix.cpp  ./vinecop/tools_select.cpp  ./vinecop/fit_controls.cpp  \
               ./RcppExports.cpp ./bicop_wrappers.cpp ./vinecop_wrappers.cpp
-SOURCES_C   = ./misc/tools_c.c
+SOURCES_C   = ./misc/tools_c.c ./init.c
 
 OBJECTS = $(SOURCES_CPP:.cpp=.o) $(SOURCES_C:.c=.o)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -10,6 +10,6 @@ SOURCES_CPP = ./bicop/abstract.cpp	  ./bicop/bb7.cpp      ./bicop/elliptical.cpp
               ./misc/tools_integration.cpp  ./misc/tools_stats.cpp \
               ./vinecop/class.cpp  ./vinecop/rvine_matrix.cpp  ./vinecop/tools_select.cpp  ./vinecop/fit_controls.cpp  \
               ./RcppExports.cpp ./bicop_wrappers.cpp ./vinecop_wrappers.cpp
-SOURCES_C   = ./misc/tools_c.c
+SOURCES_C   = ./misc/tools_c.c ./init.c
 
 OBJECTS = $(SOURCES_CPP:.cpp=.o) $(SOURCES_C:.c=.o)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -233,30 +233,3 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-
-static const R_CallMethodDef CallEntries[] = {
-    {"_rvinecopulib_bicop_check_cpp", (DL_FUNC) &_rvinecopulib_bicop_check_cpp, 1},
-    {"_rvinecopulib_bicop_select_cpp", (DL_FUNC) &_rvinecopulib_bicop_select_cpp, 7},
-    {"_rvinecopulib_bicop_pdf_cpp", (DL_FUNC) &_rvinecopulib_bicop_pdf_cpp, 2},
-    {"_rvinecopulib_bicop_cdf_cpp", (DL_FUNC) &_rvinecopulib_bicop_cdf_cpp, 2},
-    {"_rvinecopulib_bicop_hfunc1_cpp", (DL_FUNC) &_rvinecopulib_bicop_hfunc1_cpp, 2},
-    {"_rvinecopulib_bicop_hfunc2_cpp", (DL_FUNC) &_rvinecopulib_bicop_hfunc2_cpp, 2},
-    {"_rvinecopulib_bicop_hinv1_cpp", (DL_FUNC) &_rvinecopulib_bicop_hinv1_cpp, 2},
-    {"_rvinecopulib_bicop_hinv2_cpp", (DL_FUNC) &_rvinecopulib_bicop_hinv2_cpp, 2},
-    {"_rvinecopulib_bicop_loglik_cpp", (DL_FUNC) &_rvinecopulib_bicop_loglik_cpp, 2},
-    {"_rvinecopulib_bicop_par_to_tau_cpp", (DL_FUNC) &_rvinecopulib_bicop_par_to_tau_cpp, 1},
-    {"_rvinecopulib_bicop_tau_to_par_cpp", (DL_FUNC) &_rvinecopulib_bicop_tau_to_par_cpp, 2},
-    {"_rvinecopulib_rvine_matrix_check_cpp", (DL_FUNC) &_rvinecopulib_rvine_matrix_check_cpp, 1},
-    {"_rvinecopulib_vinecop_check_cpp", (DL_FUNC) &_rvinecopulib_vinecop_check_cpp, 1},
-    {"_rvinecopulib_vinecop_inverse_rosenblatt_cpp", (DL_FUNC) &_rvinecopulib_vinecop_inverse_rosenblatt_cpp, 2},
-    {"_rvinecopulib_vinecop_pdf_cpp", (DL_FUNC) &_rvinecopulib_vinecop_pdf_cpp, 2},
-    {"_rvinecopulib_vinecop_cdf_cpp", (DL_FUNC) &_rvinecopulib_vinecop_cdf_cpp, 3},
-    {"_rvinecopulib_vinecop_loglik_cpp", (DL_FUNC) &_rvinecopulib_vinecop_loglik_cpp, 2},
-    {"_rvinecopulib_vinecop_select_cpp", (DL_FUNC) &_rvinecopulib_vinecop_select_cpp, 14},
-    {NULL, NULL, 0}
-};
-
-RcppExport void R_init_rvinecopulib(DllInfo *dll) {
-    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
-    R_useDynamicSymbols(dll, FALSE);
-}

--- a/src/bicop_wrappers.cpp
+++ b/src/bicop_wrappers.cpp
@@ -3,8 +3,8 @@
 #include <Rinternals.h>
 #include <R_ext/Rdynload.h>
 #include "bicop_wrappers.hpp"
-using namespace vinecopulib;
 
+using namespace vinecopulib;
 
 BicopFamily to_cpp_family(const std::string& fam)
 {

--- a/src/bicop_wrappers.cpp
+++ b/src/bicop_wrappers.cpp
@@ -1,7 +1,4 @@
 #include <RcppEigen.h>
-#include <R.h>
-#include <Rinternals.h>
-#include <R_ext/Rdynload.h>
 #include "bicop_wrappers.hpp"
 
 using namespace vinecopulib;

--- a/src/bicop_wrappers.cpp
+++ b/src/bicop_wrappers.cpp
@@ -1,4 +1,7 @@
 #include <RcppEigen.h>
+#include <R.h>
+#include <Rinternals.h>
+#include <R_ext/Rdynload.h>
 #include "bicop_wrappers.hpp"
 using namespace vinecopulib;
 

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,56 @@
+#include <R.h>
+#include <Rinternals.h>
+#include <stdlib.h> // for NULL
+#include <R_ext/Rdynload.h>
+
+/* FIXME: 
+   Check these declarations against the C/Fortran source code.
+*/
+
+/* .Call calls */
+extern SEXP _rvinecopulib_bicop_cdf_cpp(SEXP, SEXP);
+extern SEXP _rvinecopulib_bicop_check_cpp(SEXP);
+extern SEXP _rvinecopulib_bicop_hfunc1_cpp(SEXP, SEXP);
+extern SEXP _rvinecopulib_bicop_hfunc2_cpp(SEXP, SEXP);
+extern SEXP _rvinecopulib_bicop_hinv1_cpp(SEXP, SEXP);
+extern SEXP _rvinecopulib_bicop_hinv2_cpp(SEXP, SEXP);
+extern SEXP _rvinecopulib_bicop_loglik_cpp(SEXP, SEXP);
+extern SEXP _rvinecopulib_bicop_par_to_tau_cpp(SEXP);
+extern SEXP _rvinecopulib_bicop_pdf_cpp(SEXP, SEXP);
+extern SEXP _rvinecopulib_bicop_select_cpp(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP _rvinecopulib_bicop_tau_to_par_cpp(SEXP, SEXP);
+extern SEXP _rvinecopulib_rvine_matrix_check_cpp(SEXP);
+extern SEXP _rvinecopulib_vinecop_cdf_cpp(SEXP, SEXP, SEXP);
+extern SEXP _rvinecopulib_vinecop_check_cpp(SEXP);
+extern SEXP _rvinecopulib_vinecop_inverse_rosenblatt_cpp(SEXP, SEXP);
+extern SEXP _rvinecopulib_vinecop_loglik_cpp(SEXP, SEXP);
+extern SEXP _rvinecopulib_vinecop_pdf_cpp(SEXP, SEXP);
+extern SEXP _rvinecopulib_vinecop_select_cpp(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+
+static const R_CallMethodDef CallEntries[] = {
+    {"_rvinecopulib_bicop_cdf_cpp",                  (DL_FUNC) &_rvinecopulib_bicop_cdf_cpp,                   2},
+    {"_rvinecopulib_bicop_check_cpp",                (DL_FUNC) &_rvinecopulib_bicop_check_cpp,                 1},
+    {"_rvinecopulib_bicop_hfunc1_cpp",               (DL_FUNC) &_rvinecopulib_bicop_hfunc1_cpp,                2},
+    {"_rvinecopulib_bicop_hfunc2_cpp",               (DL_FUNC) &_rvinecopulib_bicop_hfunc2_cpp,                2},
+    {"_rvinecopulib_bicop_hinv1_cpp",                (DL_FUNC) &_rvinecopulib_bicop_hinv1_cpp,                 2},
+    {"_rvinecopulib_bicop_hinv2_cpp",                (DL_FUNC) &_rvinecopulib_bicop_hinv2_cpp,                 2},
+    {"_rvinecopulib_bicop_loglik_cpp",               (DL_FUNC) &_rvinecopulib_bicop_loglik_cpp,                2},
+    {"_rvinecopulib_bicop_par_to_tau_cpp",           (DL_FUNC) &_rvinecopulib_bicop_par_to_tau_cpp,            1},
+    {"_rvinecopulib_bicop_pdf_cpp",                  (DL_FUNC) &_rvinecopulib_bicop_pdf_cpp,                   2},
+    {"_rvinecopulib_bicop_select_cpp",               (DL_FUNC) &_rvinecopulib_bicop_select_cpp,                7},
+    {"_rvinecopulib_bicop_tau_to_par_cpp",           (DL_FUNC) &_rvinecopulib_bicop_tau_to_par_cpp,            2},
+    {"_rvinecopulib_rvine_matrix_check_cpp",         (DL_FUNC) &_rvinecopulib_rvine_matrix_check_cpp,          1},
+    {"_rvinecopulib_vinecop_cdf_cpp",                (DL_FUNC) &_rvinecopulib_vinecop_cdf_cpp,                 3},
+    {"_rvinecopulib_vinecop_check_cpp",              (DL_FUNC) &_rvinecopulib_vinecop_check_cpp,               1},
+    {"_rvinecopulib_vinecop_inverse_rosenblatt_cpp", (DL_FUNC) &_rvinecopulib_vinecop_inverse_rosenblatt_cpp,  2},
+    {"_rvinecopulib_vinecop_loglik_cpp",             (DL_FUNC) &_rvinecopulib_vinecop_loglik_cpp,              2},
+    {"_rvinecopulib_vinecop_pdf_cpp",                (DL_FUNC) &_rvinecopulib_vinecop_pdf_cpp,                 2},
+    {"_rvinecopulib_vinecop_select_cpp",             (DL_FUNC) &_rvinecopulib_vinecop_select_cpp,             14},
+    {NULL, NULL, 0}
+};
+
+void R_init_rvinecopulib(DllInfo *dll)
+{
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/src/vinecop_wrappers.cpp
+++ b/src/vinecop_wrappers.cpp
@@ -1,4 +1,8 @@
 #include <RcppEigen.h>
+#include <R.h>
+#include <Rinternals.h>
+#include <stdlib.h> // for NULL
+#include <R_ext/Rdynload.h>
 #include "bicop_wrappers.hpp"
 
 using namespace vinecopulib;

--- a/src/vinecop_wrappers.cpp
+++ b/src/vinecop_wrappers.cpp
@@ -1,7 +1,4 @@
 #include <RcppEigen.h>
-#include <R.h>
-#include <Rinternals.h>
-#include <R_ext/Rdynload.h>
 #include "bicop_wrappers.hpp"
 
 using namespace vinecopulib;

--- a/src/vinecop_wrappers.cpp
+++ b/src/vinecop_wrappers.cpp
@@ -1,7 +1,6 @@
 #include <RcppEigen.h>
 #include <R.h>
 #include <Rinternals.h>
-#include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
 #include "bicop_wrappers.hpp"
 


### PR DESCRIPTION
So, everything works, and at the last minute, I noticed a NOTE in the windows builds:

```
Warning in read_symbols_from_dll(so, rarch) :
  this requires 'objdump.exe' to be on the PATH
Warning in read_symbols_from_dll(so, rarch) :
  this requires 'objdump.exe' to be on the PATH
Warning in read_symbols_from_dll(so, rarch) :
  this requires 'objdump.exe' to be on the PATH
File 'rvinecopulib/libs/i386/rvinecopulib.dll':
  Found no calls to: 'R_registerRoutines', 'R_useDynamicSymbols'
It is good practice to register native routines and to disable symbol
search.
```

It is extremely weird since such functions are called in RcppExports.cpp, any idea?

It is not a big deal for now as the winbuilder does not show the same error, but it would be nice to solve in the future...