### PR TITLE
Enhance sanity checks for `vinecop_dist()`

### DIFF
--- a/R/vinecop.R
+++ b/R/vinecop.R
@@ -133,14 +133,17 @@ vinecop <- function(data, family_set = "all", matrix = NA,
 #' @rdname vinecop
 #' @export
 vinecop_dist <- function(pair_copulas, matrix) {
-    # create object
+    ## create object
     vinecop <- structure(
         list(pair_copulas = pair_copulas, matrix = matrix),
         class = "vinecop_dist"
     )
     
-    # sanity checks
+    ## sanity checks
     stopifnot(is.list(pair_copulas))
+    d <- ncol(matrix)
+    stopifnot(length(pair_copulas) == d - 1)
+    stopifnot(identical(sapply(pair_copulas, length), rev(seq_len(d - 1))))
     pc_lst <- unlist(pair_copulas, recursive = FALSE)
     if (!all(sapply(pc_lst, function(x) inherits(x, "bicop_dist")))) {
         stop("some objects in pair_copulas aren't of class 'bicop_dist'")

--- a/tests/testthat/test_vinecop_dist.R
+++ b/tests/testthat/test_vinecop_dist.R
@@ -21,7 +21,20 @@ test_that("d/p/r- functions work", {
     expect_lte(max(pvinecop(u, vc, 100)), 1)
 })
 
-test_that("constructor catches wrong R-vine matrix", {
+test_that("constructor catches wrong input", {
+    # wrong number of trees
+    expect_error(vinecop_dist(pcs[-1], mat))
+    
+    # wrong number of pcs
+    pcs2 <- pcs
+    pcs2[[1]][[2]] <- NULL
+    expect_error(vinecop_dist(pcs[-1], mat))
+    
+    # not all pcs are of class 'bicop_dist'
+    pcs2[[1]][[2]] <- list(this = "stupid")
+    expect_error(vinecop_dist(pcs2, mat))
+    
+    # wrong R-vine matrix
     mat[3, 3] <- 5
     expect_error(vinecop_dist(pcs, mat))
 })


### PR DESCRIPTION
Add checks for the correct number of pair-copulas supplied to `vinecop_dist()` (segfaults otherwise). 