### PR TITLE
ensure `std::cout` initialization

### DIFF
--- a/inst/include/vinecopulib/misc/tools_interface.hpp
+++ b/inst/include/vinecopulib/misc/tools_interface.hpp
@@ -16,7 +16,7 @@
     #include <RcppThread.h>
     #define cout Rcout
     namespace std {
-        extern RcppThread::RPrinter Rcout;
+        static RcppThread::RPrinter Rcout = RcppThread::RPrinter();
     }
 #else
     #include <iostream>


### PR DESCRIPTION
This should fix https://www.r-project.org/nosvn/R.check/r-release-osx-x86_64/rvinecopulib-00check.html.