### PR TITLE
catch na in ktau_to_par

### DIFF
--- a/R/bicop_methods.R
+++ b/R/bicop_methods.R
@@ -168,6 +168,7 @@ par_to_ktau <- function(family, rotation, parameters) {
 #' @param tau Kendall's \eqn{\tau}.
 #' @export
 ktau_to_par <- function(family, tau) {
+  assert_that(is.number(tau), !is.na(tau))
   bicop <- args2bicop(family)
   if (!(bicop$family %in% family_set_rotationless)) {
     bicop$rotation <- ifelse(tau > 0, 0, 90)


### PR DESCRIPTION
Just to give a better error message than (current version):
```r
 Error in bicop_tau_to_par_cpp(bicop, tau) : rotation must be one of {0, 90, 180, 270}
```