### PR TITLE
tree restriction in summary functions

### DIFF
--- a/R/vine_methods.R
+++ b/R/vine_methods.R
@@ -228,7 +228,10 @@ print.vine <- function(x, ...) {
 
 #' @export
 summary.vine <- function(object, ...) {
-  summary.vine_dist(object, ...)
+  list(
+    margins = get_vine_margin_summary(object),
+    copula = summary(object$copula)
+  )
 }
 
 get_vine_margin_summary <- function(object) {

--- a/R/vine_methods.R
+++ b/R/vine_methods.R
@@ -147,7 +147,7 @@ print.vine_dist <- function(x, ...) {
 summary.vine_dist <- function(object, ...) {
   list(
     margins = get_vine_dist_margin_summary(object),
-    copula = summary(object$copula)
+    copula = summary(object$copula, ...)
   )
 }
 
@@ -228,10 +228,7 @@ print.vine <- function(x, ...) {
 
 #' @export
 summary.vine <- function(object, ...) {
-  list(
-    margins = get_vine_margin_summary(object),
-    copula = summary(object$copula)
-  )
+  summary.vine_dist(object, ...)
 }
 
 get_vine_margin_summary <- function(object) {

--- a/R/vinecop_methods.R
+++ b/R/vinecop_methods.R
@@ -120,11 +120,13 @@ print.vinecop_dist <- function(x, ...) {
 
 #' @importFrom utils capture.output
 #' @export
-summary.vinecop_dist <- function(object, ...) {
+summary.vinecop_dist <- function(object,
+                                 trees = seq_len(dim(object)["trunc_lvl"]),
+                                 ...) {
   mat <- as_rvine_matrix(get_structure(object))
   d <- dim(object)[1]
-  n_trees <- dim(object)[2]
-  n_pcs <- length(unlist(object$pair_copulas, recursive = FALSE))
+  trees <- intersect(trees, seq_len(dim(object)["trunc_lvl"]))
+  n_pcs <- length(unlist(object$pair_copulas[trees], recursive = FALSE))
   mdf <- as.data.frame(matrix(NA, n_pcs, 10))
   names(mdf) <- c(
     "tree", "edge",
@@ -132,7 +134,7 @@ summary.vinecop_dist <- function(object, ...) {
     "family", "rotation", "parameters", "df", "tau"
   )
   k <- 1
-  for (t in seq_len(n_trees)) {
+  for (t in trees) {
     for (e in seq_len(d - t)) {
       mdf$tree[k] <- t
       mdf$edge[k] <- e
@@ -293,13 +295,12 @@ print.vinecop <- function(x, ...) {
 
 
 #' @export
-summary.vinecop <- function(object, ...) {
-  mdf <- summary.vinecop_dist(object)
-
+summary.vinecop <- function(object, trees = seq_len(dim(object)["trunc_lvl"]), ...) {
+  trees <- intersect(trees, seq_len(dim(object)["trunc_lvl"]))
+  mdf <- summary.vinecop_dist(object, trees)
   d <- dim(object)[1]
-  trunc_lvl <- dim(object)[2]
   k <- 1
-  for (t in seq_len(trunc_lvl)) {
+  for (t in trees) {
     for (e in seq_len(d - t)) {
       mdf$loglik[k] <- object$pair_copulas[[t]][[e]]$loglik
       k <- k + 1

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // pseudo_obs_cpp
 Eigen::MatrixXd pseudo_obs_cpp(Eigen::MatrixXd x, std::string ties_method);
 RcppExport SEXP _rvinecopulib_pseudo_obs_cpp(SEXP xSEXP, SEXP ties_methodSEXP) {


### PR DESCRIPTION
The summary function does some computations for each pair copulas. For large models, this may take a long time to run. In such cases it can be very useful to focus on some small range of trees.