### PR TITLE
Better revdep check

### DIFF
--- a/.github/workflows/revdepcheck.yaml
+++ b/.github/workflows/revdepcheck.yaml
@@ -29,19 +29,27 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
+      - uses: r-lib/actions/setup-tinytex@v2
+
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
-          needs: check
+          extra-packages: |
+            any::rcmdcheck
+            any::devtools
+            any::fs
+            any::gsl
+            any::units
+            any::terra
+            any::vdiffr
+            any::textshaping
 
       - name: Reverse dependency check
         shell: Rscript {0}
         run: |
-          install.packages(c("devtools", "fs"))
           fs::dir_create("../revdeps")
           devtools::build(path = "../revdeps/")
           tools::check_packages_in_dir("../revdeps", reverse = list(which = "all"))

--- a/.github/workflows/revdepcheck.yaml
+++ b/.github/workflows/revdepcheck.yaml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'devel'}
-          - {os: ubuntu-latest,   r: 'devel'}
+          - {os: ubuntu-22.04,   r: 'devel'}
+          - {os: windows-latest,   r: 'devel'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -51,11 +51,15 @@ jobs:
         run: |
           fs::dir_create("../revdeps")
           devtools::build(path = "../revdeps/")
-          tools::check_packages_in_dir("../revdeps", reverse = list(which = "all"))
+          tools::check_packages_in_dir(
+            "../revdeps", 
+            reverse = list(which = "all"), 
+            check_args = c("--as-cran", "--no-manual")
+          )
 
       - name: Results
         shell: Rscript {0}
         run: |
-          tools::summarize_check_packages_in_dir_timings("../revdeps")
-          tools::summarize_check_packages_in_dir_depends("../revdeps")
+          tools::summarize_check_packages_in_dir_timings("../revdeps", all = TRUE)
           tools::summarize_check_packages_in_dir_results("../revdeps")
+          tools::check_packages_in_dir_details("../revdeps")

--- a/.github/workflows/revdepcheck.yaml
+++ b/.github/workflows/revdepcheck.yaml
@@ -54,7 +54,7 @@ jobs:
           tools::check_packages_in_dir(
             "../revdeps", 
             reverse = list(which = "all"), 
-            check_args = c("--as-cran", "--no-manual")
+            check_args = c("--no-manual")
           )
 
       - name: Results

--- a/.github/workflows/revdepcheck.yaml
+++ b/.github/workflows/revdepcheck.yaml
@@ -41,7 +41,10 @@ jobs:
       - name: Reverse dependency check
         shell: Rscript {0}
         run: |
-          install.packages("remotes")
-          remotes::install_github("r-lib/revdepcheck")
-          revdepcheck::revdep_check(bioc = FALSE)
-
+          install.packages(c("devtools", "fs"))
+          fs::dir_create("../revdeps")
+          devtools::build(path = "../revdeps/")
+          tools::check_packages_in_dir("../revdeps", reverse = list(which = "all"))
+          tools::summarize_check_packages_in_dir_timings("../revdeps")
+          tools::summarize_check_packages_in_dir_depends("../revdeps")
+          tools::summarize_check_packages_in_dir_results("../revdeps")

--- a/.github/workflows/revdepcheck.yaml
+++ b/.github/workflows/revdepcheck.yaml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'devel'}
           - {os: windows-latest, r: 'devel'}
           - {os: ubuntu-latest,   r: 'devel'}
 
@@ -53,6 +52,10 @@ jobs:
           fs::dir_create("../revdeps")
           devtools::build(path = "../revdeps/")
           tools::check_packages_in_dir("../revdeps", reverse = list(which = "all"))
+
+      - name: Results
+        shell: Rscript {0}
+        run: |
           tools::summarize_check_packages_in_dir_timings("../revdeps")
           tools::summarize_check_packages_in_dir_depends("../revdeps")
           tools::summarize_check_packages_in_dir_results("../revdeps")


### PR DESCRIPTION
Without revdepcheck package, which somehow showed Surrogate as OK. 

The tests are green even if some reverse dependencies fail (because that's not always under our control). The trst results should be inspected manually before merging to main.