### PR TITLE
fix deprecation warning in json header

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rvinecopulib
 Type: Package
 Title: High Performance Algorithms for Vine Copula Modeling
-Version: 0.7.1.1.1
+Version: 0.7.1.1.2
 Authors@R: c(
         person("Thomas", "Nagler",, "info@vinecopulib.org", role = c("aut", "cre")),
         person("Thibault", "Vatter",, "info@vinecopulib.org", role = c("aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# rvinecopulib 0.7.1.1.2
+
+BUG FIX
+
+* Fixes "deprecated-literal-operator" warning on clang20.
+
 # rvinecopulib 0.7.1.1.1
 
 BUG FIX

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,5 @@
+Fixes "deprecated-literal-operator" warning on clang20 (r-devel-linux-x86_64-fedora-clang)
+
 ## Test environments
 
 * CRAN win builder (devel)

--- a/inst/include/vinecopulib/misc/nlohmann_json.hpp
+++ b/inst/include/vinecopulib/misc/nlohmann_json.hpp
@@ -25223,7 +25223,7 @@ template<template<typename, typename, typename...> class ObjectType,       \
            @since version 1.0.0
            */
           JSON_HEDLEY_NON_NULL(1)
-            inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+            inline nlohmann::json operator ""_json(const char* s, std::size_t n)
             {
               return nlohmann::json::parse(s, s + n);
             }
@@ -25242,7 +25242,7 @@ template<template<typename, typename, typename...> class ObjectType,       \
            @since version 2.0.0
            */
           JSON_HEDLEY_NON_NULL(1)
-            inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+            inline nlohmann::json::json_pointer operator ""_json_pointer(const char* s, std::size_t n)
             {
               return nlohmann::json::json_pointer(std::string(s, n));
             }


### PR DESCRIPTION
Fixes CRAN warning

```
Version: 0.7.1.1.1
Check: whether package can be installed
Result: WARN 
  Found the following significant warnings:
    ../inst/include/vinecopulib/misc/nlohmann_json.hpp:25226:47: warning: identifier '_json' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
    ../inst/include/vinecopulib/misc/nlohmann_json.hpp:25245:61: warning: identifier '_json_pointer' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
  See ‘/data/gannet/ripley/R/packages/tests-clang/rvinecopulib.Rcheck/00install.out’ for details.
  * used C++ compiler: ‘clang version 20.1.0-rc2’
```