### PR TITLE
Fix crashes with vectorized bicop parameters

### DIFF
--- a/inst/include/vinecopulib-wrappers.hpp
+++ b/inst/include/vinecopulib-wrappers.hpp
@@ -118,7 +118,9 @@ inline Bicop bicop_wrap(const Rcpp::List& bicop_r)
       const size_t p = expected_npars(family);
       if (par.cols() == 1) {
         if ((p == 1) && (par.rows() > 1)) {
-          par = par.topRows(1);
+          // .eval() materializes the first row before the self-aliased resize
+          // reallocates par's buffer (see the two-parameter branch below).
+          par = par.topRows(1).eval();
         }
       } else {
         if ((p > 0) && (static_cast<size_t>(par.cols()) == p)) {

--- a/inst/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/inst/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -283,9 +283,10 @@ AbstractBicop::pdf_c_d(const Eigen::MatrixXd& u,
     udiff = (u.col(1) - u.col(3)).cwiseAbs();
   }
 
-  const bool bc = (parameters.rows() == 1);
+  const bool bc = (parameters.rows() != u.rows());
   for (Eigen::Index i = 0; i < u.rows(); i++) {
-    const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
+    const Eigen::MatrixXd par_i =
+        parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
     if (udiff(i) > 5e-5) {
       if (var_types_[0] != "c") {
         pdf(i) =
@@ -311,9 +312,10 @@ AbstractBicop::pdf_d_d(const Eigen::MatrixXd& u,
   Eigen::MatrixXd umin = u.rightCols(2);
   Eigen::MatrixXd udiff = (umax - umin).cwiseAbs();
 
-  const bool bc = (parameters.rows() == 1);
+  const bool bc = (parameters.rows() != u.rows());
   for (Eigen::Index i = 0; i < u.rows(); i++) {
-    const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
+    const Eigen::MatrixXd par_i =
+        parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
     // the difference quotient can be instable, use derivative if denominator
     // too small
     if (udiff.row(i).maxCoeff() < 5e-5) {
@@ -351,9 +353,10 @@ AbstractBicop::hfunc1(const Eigen::MatrixXd& u,
     auto u1diff = (uu.col(0) - uu.col(2)).cwiseAbs();
     Eigen::VectorXd h(u.rows());
 
-    const bool bc = (parameters.rows() == 1);
+    const bool bc = (parameters.rows() != u.rows());
     for (Eigen::Index i = 0; i < u.rows(); i++) {
-      const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
+      const Eigen::MatrixXd par_i =
+        parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
       if (std::abs(u1diff(i)) > 5e-5) {
         h(i) = cdf(uu.row(i).leftCols(2), par_i)(0) -
                cdf(uu.row(i).rightCols(2), par_i)(0);
@@ -379,9 +382,10 @@ AbstractBicop::hfunc2(const Eigen::MatrixXd& u,
     auto u2diff = (uu.col(1) - uu.col(3)).cwiseAbs();
     Eigen::VectorXd h(u.rows());
 
-    const bool bc = (parameters.rows() == 1);
+    const bool bc = (parameters.rows() != u.rows());
     for (Eigen::Index i = 0; i < u.rows(); i++) {
-      const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
+      const Eigen::MatrixXd par_i =
+        parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
       if (u2diff(i) > 5e-5) {
         h(i) = cdf(uu.row(i).leftCols(2), par_i)(0) -
                cdf(uu.row(i).rightCols(2), par_i)(0);

--- a/inst/include/vinecopulib/bicop/implementation/parametric.ipp
+++ b/inst/include/vinecopulib/bicop/implementation/parametric.ipp
@@ -214,23 +214,25 @@ ParBicop::check_parameters(const Eigen::MatrixXd& parameters)
 inline void
 ParBicop::check_parameters_size(const Eigen::MatrixXd& parameters)
 {
-  if (parameters.size() != parameters_.size()) {
-    if (parameters.rows() != parameters_.rows()) {
-      std::stringstream message;
-      message << "parameters have has wrong number of rows "
-              << "for " << get_family_name() << " copula; "
-              << "expected: " << parameters_.rows() << ", "
-              << "actual: " << parameters.rows() << std::endl;
-      throw std::runtime_error(message.str().c_str());
-    }
-    if (parameters.cols() != parameters_.cols()) {
-      std::stringstream message;
-      message << "parameters have wrong number of columns "
-              << "for " << get_family_name() << " copula; "
-              << "expected: " << parameters_.cols() << ", "
-              << "actual: " << parameters.cols() << std::endl;
-      throw std::runtime_error(message.str().c_str());
-    }
+  // Validate rows and cols unconditionally: a same-size-but-transposed shape
+  // (e.g. 1 x p vs p x 1) would otherwise slip through and reach the
+  // coefficient-wise bound comparisons in check_parameters_lower/_upper with
+  // mismatched shapes (an out-of-bounds read under NDEBUG).
+  if (parameters.rows() != parameters_.rows()) {
+    std::stringstream message;
+    message << "parameters have has wrong number of rows "
+            << "for " << get_family_name() << " copula; "
+            << "expected: " << parameters_.rows() << ", "
+            << "actual: " << parameters.rows() << std::endl;
+    throw std::runtime_error(message.str().c_str());
+  }
+  if (parameters.cols() != parameters_.cols()) {
+    std::stringstream message;
+    message << "parameters have wrong number of columns "
+            << "for " << get_family_name() << " copula; "
+            << "expected: " << parameters_.cols() << ", "
+            << "actual: " << parameters.cols() << std::endl;
+    throw std::runtime_error(message.str().c_str());
   }
 }
 

--- a/tests/testthat/test_bicop_dist.R
+++ b/tests/testthat/test_bicop_dist.R
@@ -208,8 +208,12 @@ test_that("vectorized parameters work for every one-parameter family (#320)", {
     by_row <- function(f) vapply(seq_len(n), f, numeric(1))
     d_row <- by_row(function(i) dbicop(u[i, ], fam, 0, pars[i, , drop = FALSE]))
     p_row <- by_row(function(i) pbicop(u[i, ], fam, 0, pars[i, , drop = FALSE]))
-    h1_row <- by_row(function(i) hbicop(u[i, ], 1, fam, 0, pars[i, , drop = FALSE]))
-    h2_row <- by_row(function(i) hbicop(u[i, ], 2, fam, 0, pars[i, , drop = FALSE]))
+    h1_row <- by_row(function(i) {
+      hbicop(u[i, ], 1, fam, 0, pars[i, , drop = FALSE])
+    })
+    h2_row <- by_row(function(i) {
+      hbicop(u[i, ], 2, fam, 0, pars[i, , drop = FALSE])
+    })
     hi1_row <- by_row(function(i) {
       hbicop(u[i, ], 1, fam, 0, pars[i, , drop = FALSE], inverse = TRUE)
     })

--- a/tests/testthat/test_bicop_dist.R
+++ b/tests/testthat/test_bicop_dist.R
@@ -180,6 +180,63 @@ test_that("vectorized parameters work for dbicop/pbicop/hbicop", {
   expect_equal(hi_vec, hi_row)
 })
 
+test_that("vectorized parameters work for every one-parameter family (#320)", {
+  # Regression guard for the Eigen self-aliasing bug in bicop_wrap(): the
+  # earlier Gaussian-only test could not catch it because Gaussian's lower
+  # bound (-1) swallows the subnormal garbage, whereas clayton/gumbel/joe
+  # (positive lower bounds) throw "parameters exceed lower bound". Loop over
+  # all one-parameter families, generating valid per-row parameters generically
+  # from a grid of Kendall's taus via ktau_to_par().
+  set.seed(11)
+  n <- 40
+  u <- matrix(runif(2 * n), ncol = 2)
+  taus <- seq(0.1, 0.7, length.out = n)
+
+  for (fam in family_set_onepar) {
+    pars <- matrix(
+      vapply(taus, function(tt) as.numeric(ktau_to_par(fam, tt)), numeric(1)),
+      ncol = 1
+    )
+
+    d_vec <- dbicop(u, fam, 0, pars)
+    p_vec <- pbicop(u, fam, 0, pars)
+    h1_vec <- hbicop(u, 1, fam, 0, pars)
+    h2_vec <- hbicop(u, 2, fam, 0, pars)
+    hi1_vec <- hbicop(u, 1, fam, 0, pars, inverse = TRUE)
+    hi2_vec <- hbicop(u, 2, fam, 0, pars, inverse = TRUE)
+
+    by_row <- function(f) vapply(seq_len(n), f, numeric(1))
+    d_row <- by_row(function(i) dbicop(u[i, ], fam, 0, pars[i, , drop = FALSE]))
+    p_row <- by_row(function(i) pbicop(u[i, ], fam, 0, pars[i, , drop = FALSE]))
+    h1_row <- by_row(function(i) hbicop(u[i, ], 1, fam, 0, pars[i, , drop = FALSE]))
+    h2_row <- by_row(function(i) hbicop(u[i, ], 2, fam, 0, pars[i, , drop = FALSE]))
+    hi1_row <- by_row(function(i) {
+      hbicop(u[i, ], 1, fam, 0, pars[i, , drop = FALSE], inverse = TRUE)
+    })
+    hi2_row <- by_row(function(i) {
+      hbicop(u[i, ], 2, fam, 0, pars[i, , drop = FALSE], inverse = TRUE)
+    })
+
+    expect_eql(d_vec, d_row, info = fam)
+    expect_eql(p_vec, p_row, info = fam)
+    expect_eql(h1_vec, h1_row, info = fam)
+    expect_eql(h2_vec, h2_row, info = fam)
+    expect_eql(hi1_vec, hi1_row, info = fam)
+    expect_eql(hi2_vec, hi2_row, info = fam)
+    expect_true(all(is.finite(d_vec)), info = fam)
+  }
+})
+
+test_that("reported Clayton vectorized-parameter crash is fixed (#320)", {
+  set.seed(123)
+  n <- 10
+  u <- matrix(runif(n * 2), ncol = 2)
+  par <- matrix(runif(n, 2, 3), ncol = 1)
+  res <- dbicop(u = u, family = "clayton", parameters = par)
+  expect_length(res, n)
+  expect_true(all(is.finite(res)))
+})
+
 test_that("vectorized parameters are rejected by bicop_dist objects", {
   set.seed(8)
   n <- 40


### PR DESCRIPTION
## Problem

```r
u   <- matrix(runif(20), ncol = 2)
par <- matrix(runif(10, 2, 3), ncol = 1)   # valid, in [2, 3]
dbicop(u, "clayton", parameters = par)
#> Error: parameters exceed lower bound for Clayton copula;
#>   bound: 1e-10   actual: 4.77025e-310
```

`4.77025e-310` is a subnormal double — a read of uninitialized memory.

## Cause

`bicop_wrap()` reduced vectorized parameters with `par = par.topRows(1)`, an Eigen self-aliasing assignment: the resize frees `par`'s buffer before the copy runs, so the `Bicop` was constructed with garbage and `check_parameters` threw **at construction** (before the vectorized `pdf` was reached). Only one-parameter families with a positive lower bound (clayton/gumbel/joe) surfaced it; gaussian/frank silently swallowed the garbage — which is why the existing Gaussian-only test never caught it.

## Fix

- `inst/include/vinecopulib-wrappers.hpp`: `par = par.topRows(1).eval()`.
- Vendored vinecopulib sources (companion upstream PR vinecopulib/vinecopulib#700):
  - `abstract.ipp`: discrete per-row leaves no longer index the parameter matrix out of bounds for parameterless (indep) / nonparametric (tll) copulas.
  - `parametric.ipp`: `check_parameters_size` validates rows and cols unconditionally.
- Regression test over all one-parameter families (vectorized == row-by-row) plus the reported clayton case.

## Verification

Full `devtools::test()` passes (600); the only failures are pre-existing and environmental (optional `ggraph` not installed → 2 `plot()` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
