### PR TITLE
Add conditional simulation APIs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@ The main changes on the R end are:
 * aligned the R frontend with the updated vinecopulib 0.8.0 API and tests,
   including the new per-row bicop parameter interface.
 
+* added conditioning-aware vine selection and conditional simulation with
+  `rvinecop()` and `rvine()`.
+
 # rvinecopulib 0.7.3.1.0
 
 ### NEW FEATURES

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -89,6 +89,10 @@ vinecop_sim_cpp <- function(vinecop_r, n, qrng, cores, seeds) {
     .Call(`_rvinecopulib_vinecop_sim_cpp`, vinecop_r, n, qrng, cores, seeds)
 }
 
+vinecop_sim_conditional_cpp <- function(vinecop_r, u_cond, conditioning_set, qrng, cores, seeds) {
+    .Call(`_rvinecopulib_vinecop_sim_conditional_cpp`, vinecop_r, u_cond, conditioning_set, qrng, cores, seeds)
+}
+
 vinecop_pdf_cpp <- function(u, vinecop_r, cores) {
     .Call(`_rvinecopulib_vinecop_pdf_cpp`, u, vinecop_r, cores)
 }
@@ -109,8 +113,8 @@ vinecop_hessian_cpp <- function(u, vinecop_r, step_wise, cores) {
     .Call(`_rvinecopulib_vinecop_hessian_cpp`, u, vinecop_r, step_wise, cores)
 }
 
-vinecop_select_cpp <- function(data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds) {
-    .Call(`_rvinecopulib_vinecop_select_cpp`, data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds)
+vinecop_select_cpp <- function(data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds, conditioning_set) {
+    .Call(`_rvinecopulib_vinecop_select_cpp`, data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds, conditioning_set)
 }
 
 vinecop_fit_cpp <- function(data, vinecop_r, par_method, nonpar_method, mult, weights, show_trace, num_threads, tree_algorithm, seeds) {

--- a/R/tools.R
+++ b/R/tools.R
@@ -99,7 +99,7 @@ process_conditioning_values <- function(x, n, arg, numeric_only = FALSE) {
       lapply(seq_along(x), function(i) x[i]),
       optional = TRUE
     )
-  } else if (is.vector(x)) {
+  } else if (is.atomic(x) && is.vector(x)) {
     x <- matrix(x, nrow = 1)
   }
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -27,6 +27,108 @@ if_vec_to_matrix <- function(u, to_col = FALSE) {
   u
 }
 
+#' Internal: Validate and normalize a conditioning set.
+#' @param conditioning_set variable indices or names.
+#' @param var_names variable names, or `NULL`.
+#' @param d model dimension.
+#' @return an integer vector of 1-based variable indices.
+#' @noRd
+process_conditioning_set <- function(conditioning_set, var_names, d) {
+  if (is.null(conditioning_set) || length(conditioning_set) == 0) {
+    return(integer())
+  }
+
+  if (is.character(conditioning_set)) {
+    if (is.null(var_names)) {
+      stop(
+        "character 'conditioning_set' requires named variables.",
+        call. = FALSE
+      )
+    }
+    if (anyDuplicated(var_names)) {
+      stop(
+        "character 'conditioning_set' requires unique variable names.",
+        call. = FALSE
+      )
+    }
+    conditioning_set <- match(conditioning_set, var_names)
+    if (anyNA(conditioning_set)) {
+      stop("'conditioning_set' contains unknown variable names.", call. = FALSE)
+    }
+  } else {
+    if (
+      !is.numeric(conditioning_set) ||
+        anyNA(conditioning_set) ||
+        any(!is.finite(conditioning_set)) ||
+        any(conditioning_set != floor(conditioning_set))
+    ) {
+      stop(
+        "'conditioning_set' must contain variable indices or names.",
+        call. = FALSE
+      )
+    }
+  }
+
+  conditioning_set <- as.integer(conditioning_set)
+  if (any(conditioning_set < 1L | conditioning_set > d)) {
+    stop("'conditioning_set' indices must be between 1 and d.", call. = FALSE)
+  }
+  if (anyDuplicated(conditioning_set)) {
+    stop("'conditioning_set' must not contain duplicates.", call. = FALSE)
+  }
+  if (length(conditioning_set) >= d) {
+    stop(
+      "'conditioning_set' must contain at most d - 1 variables.",
+      call. = FALSE
+    )
+  }
+
+  conditioning_set
+}
+
+#' Internal: Normalize conditioning values and recycle a single row.
+#' @param x conditioning values.
+#' @param n required number of rows.
+#' @param arg argument name used in error messages.
+#' @param numeric_only whether all values must be numeric.
+#' @return a matrix or data frame with `n` rows.
+#' @noRd
+process_conditioning_values <- function(x, n, arg, numeric_only = FALSE) {
+  if (is.factor(x)) {
+    x <- as.data.frame(
+      lapply(seq_along(x), function(i) x[i]),
+      optional = TRUE
+    )
+  } else if (is.vector(x)) {
+    x <- matrix(x, nrow = 1)
+  }
+
+  if (!is.matrix(x) && !is.data.frame(x)) {
+    stop(
+      sprintf("'%s' must be a vector, matrix, or data frame.", arg),
+      call. = FALSE
+    )
+  }
+  if (
+    numeric_only &&
+      !(is.numeric(x) ||
+        (is.data.frame(x) && all(vapply(x, is.numeric, logical(1)))))
+  ) {
+    stop(sprintf("'%s' must be numeric.", arg), call. = FALSE)
+  }
+
+  if (nrow(x) == 1L) {
+    x <- x[rep.int(1L, n), , drop = FALSE]
+  } else if (nrow(x) != n) {
+    stop(
+      sprintf("'%s' must have one or 'n' rows.", arg),
+      call. = FALSE
+    )
+  }
+
+  x
+}
+
 #' Internal: Convert arguments to `bicop_dist` object.
 #' @param family the family as passed in function call.
 #' @param rotation the rotation as passed in function call.

--- a/R/vine.R
+++ b/R/vine.R
@@ -115,7 +115,8 @@ vine <- function(
     keep_data = FALSE,
     show_trace = FALSE,
     cores = 1,
-    tree_algorithm = "mst_prim"
+    tree_algorithm = "mst_prim",
+    conditioning_set = NULL
   ),
   weights = numeric(),
   keep_data = FALSE,
@@ -183,6 +184,7 @@ prep_for_margins <- function(data) {
 compute_pseudo_obs <- function(data, vine) {
   d <- ncol(data)
   u <- dpq_marg(data, vine)
+  colnames(u) <- names(data)
   if (any(vine$copula$var_types != "c")) {
     u_sub <- u
     for (k in which(vine$copula$var_types != "c")) {

--- a/R/vine_methods.R
+++ b/R/vine_methods.R
@@ -10,6 +10,15 @@
 #' @param vine an object of class `"vine_dist"`.
 #' @param cores number of cores to use; if larger than one, computations are
 #'   done in parallel on `cores` batches .
+#' @param x_cond optional conditioning values for `rvine()` on the original
+#'   data scale. A vector or one-row object is repeated `n` times;
+#'   alternatively, supply an `n`-row matrix or data frame for
+#'   observation-specific conditioning values. If `NULL`, `rvine()` performs
+#'   unconditional simulation.
+#' @param conditioning_set variable indices or names corresponding to the
+#'   columns of `x_cond`. When `NULL`, the columns correspond to the last
+#'   variables of the current copula order. Discrete left limits are computed
+#'   internally from the fitted margins.
 #' @details
 #' See [vine] for the estimation and construction of vine models.
 #' Here, the density, distribution function and random generation
@@ -22,7 +31,7 @@
 #' (i.e., output of [vine_dist()]).
 #' @return
 #' `dvine()` gives the density, `pvine()` gives the distribution function,
-#' and `rvine()` generates random deviates.
+#' and `rvine()` generates unconditional or conditional random deviates.
 #'
 #' The length of the result is determined by `n` for `rvine()`, and
 #' the number of rows in `u` for the other functions.
@@ -108,14 +117,100 @@ pvine <- function(x, vine, n_mc = 10^4, cores = 1) {
 #' Generalized Halton sequence up to dimension 300 and the Generalized Sobol
 #' sequence in higher dimensions (default `qrng = FALSE`).
 #' @export
-rvine <- function(n, vine, qrng = FALSE, cores = 1) {
-  assert_that(inherits(vine, "vine_dist"), is.flag(qrng))
+rvine <- function(
+  n,
+  vine,
+  qrng = FALSE,
+  cores = 1,
+  x_cond = NULL,
+  conditioning_set = NULL
+) {
+  assert_that(
+    is.count(n),
+    inherits(vine, "vine_dist"),
+    is.flag(qrng),
+    is.number(cores),
+    cores > 0
+  )
 
-  # simulate copula data
-  U <- rvinecop(n, vine$copula, qrng, cores)
+  n <- as.integer(n)
+  if (is.null(x_cond)) {
+    if (!is.null(conditioning_set) && length(conditioning_set) > 0) {
+      stop("'conditioning_set' requires 'x_cond'.", call. = FALSE)
+    }
+    U <- rvinecop(n, vine$copula, qrng, cores)
+    conditioned_variables <- integer()
+  } else {
+    x_cond <- process_conditioning_values(x_cond, n, "x_cond")
+    d <- dim(vine)[1]
+    conditioning_set_supplied <-
+      !is.null(conditioning_set) && length(conditioning_set) > 0
+
+    if (conditioning_set_supplied) {
+      conditioned_variables <- process_conditioning_set(
+        conditioning_set,
+        vine$names,
+        d
+      )
+      if (ncol(x_cond) != length(conditioned_variables)) {
+        stop(
+          "'x_cond' must have one column per conditioning variable.",
+          call. = FALSE
+        )
+      }
+    } else {
+      k <- ncol(x_cond)
+      if (k < 1L || k >= d) {
+        stop("'x_cond' must have between 1 and d - 1 columns.", call. = FALSE)
+      }
+      conditioned_variables <- utils::tail(vine$copula$structure$order, k)
+    }
+
+    get_conditioning_column <- function(i) {
+      if (is.data.frame(x_cond)) x_cond[[i]] else x_cond[, i]
+    }
+    u_values <- lapply(seq_along(conditioned_variables), function(i) {
+      eval_one_dpq(
+        get_conditioning_column(i),
+        vine$margins[[conditioned_variables[i]]],
+        "p"
+      )
+    })
+    discrete_positions <- which(
+      vine$copula$var_types[conditioned_variables] == "d"
+    )
+    u_left_limits <- lapply(discrete_positions, function(i) {
+      eval_one_dpq(
+        get_conditioning_column(i),
+        vine$margins[[conditioned_variables[i]]],
+        "p_sub"
+      )
+    })
+    u_cond <- do.call(cbind, c(u_values, u_left_limits))
+
+    U <- rvinecop(
+      n,
+      vine$copula,
+      qrng,
+      cores,
+      u_cond = u_cond,
+      conditioning_set = if (conditioning_set_supplied) {
+        conditioned_variables
+      }
+    )
+  }
 
   # use quantile transformation for marginals
   X <- dpq_marg(U, vine, "q")
+  if (!is.null(x_cond)) {
+    for (i in seq_along(conditioned_variables)) {
+      if (is.data.frame(X)) {
+        X[[conditioned_variables[i]]] <- get_conditioning_column(i)
+      } else {
+        X[, conditioned_variables[i]] <- get_conditioning_column(i)
+      }
+    }
+  }
   colnames(X) <- vine$names
   X
 }

--- a/R/vinecop.R
+++ b/R/vinecop.R
@@ -43,6 +43,11 @@
 #'   algorithm to generate a random spanning tree, either with probability
 #'   proportional to the product of the edge weights (weighted) or
 #'   uniformly (unweighted).
+#' @param conditioning_set variable indices or names to place at the end of the
+#'   vine order. The resulting model can be sampled conditionally with
+#'   [rvinecop()] by supplying `u_cond`. Conditioning-aware selection requires
+#'   a full, non-truncated vine and an MST tree algorithm (`"mst_prim"` or
+#'   `"mst_kruskal"`).
 #'
 #' @details
 #'
@@ -176,7 +181,8 @@ vinecop <- function(
   vinecop_object = NULL,
   show_trace = FALSE,
   cores = 1,
-  tree_algorithm = "mst_prim"
+  tree_algorithm = "mst_prim",
+  conditioning_set = NULL
 ) {
   assert_that(
     is.character(family_set),
@@ -203,6 +209,38 @@ vinecop <- function(
     correct_var_types(var_types),
     is.string(tree_algorithm)
   )
+
+  d <- length(var_types)
+  var_names <- colnames(data)
+  if (!is.null(var_names)) {
+    var_names <- var_names[seq_len(d)]
+  }
+  conditioning_set <- process_conditioning_set(
+    conditioning_set,
+    var_names,
+    d
+  )
+  if (length(conditioning_set) > 0) {
+    if (!is.null(vinecop_object)) {
+      stop(
+        "'conditioning_set' cannot be used when refitting a 'vinecop_object'.",
+        call. = FALSE
+      )
+    }
+    if (is.na(trunc_lvl) || (is.finite(trunc_lvl) && trunc_lvl < d - 1)) {
+      stop(
+        "conditioning-aware selection requires a non-truncated vine.",
+        call. = FALSE
+      )
+    }
+    if (!tree_algorithm %in% c("mst_prim", "mst_kruskal")) {
+      stop(
+        "conditioning-aware selection requires 'tree_algorithm' to be ",
+        "'mst_prim' or 'mst_kruskal'.",
+        call. = FALSE
+      )
+    }
+  }
 
   seeds <- get_seeds()
   if (!is.null(vinecop_object)) {
@@ -265,7 +303,8 @@ vinecop <- function(
       num_threads = cores,
       var_types = var_types,
       tree_algorithm = tree_algorithm,
-      seeds = seeds
+      seeds = seeds,
+      conditioning_set = conditioning_set
     )
   }
 
@@ -292,7 +331,8 @@ vinecop <- function(
     trunc_lvl = trunc_lvl,
     tree_crit = tree_crit,
     threshold = threshold,
-    tree_algorithm = tree_algorithm
+    tree_algorithm = tree_algorithm,
+    conditioning_set = conditioning_set
   )
   vinecop$nobs <- NROW(data)
   vinecop

--- a/R/vinecop_methods.R
+++ b/R/vinecop_methods.R
@@ -16,8 +16,10 @@
 #' @param u_cond optional conditioning values for `rvinecop()`. A vector or
 #'   one-row matrix is repeated `n` times; alternatively, supply an `n`-row
 #'   matrix for observation-specific conditioning values. The first block holds
-#'   the copula-scale values \eqn{F(x)}. For discrete conditioning variables,
-#'   append their left limits \eqn{F(x^-)} in the same relative order. If
+#'   the copula-scale values \eqn{F(x)}. The expanded layout appends one
+#'   left-limit column \eqn{F(x^-)} per conditioning variable in the same order;
+#'   columns for continuous variables equal their value columns. In the compact
+#'   layout, the redundant columns for continuous variables are omitted. If
 #'   `NULL`, `rvinecop()` performs unconditional simulation.
 #' @param conditioning_set variable indices or names corresponding to the first
 #'   block of `u_cond`. When `NULL`, the columns of `u_cond` correspond to the
@@ -214,13 +216,31 @@ rvinecop <- function(
     )
     if (length(conditioning_set) > 0) {
       n_discrete <- sum(vinecop$var_types[conditioning_set] == "d")
-      expected_cols <- length(conditioning_set) + n_discrete
-      if (ncol(u_cond) != expected_cols) {
+      compact_cols <- length(conditioning_set) + n_discrete
+      expanded_cols <- 2L * length(conditioning_set)
+      if (!(ncol(u_cond) %in% c(compact_cols, expanded_cols))) {
         stop(
           "'u_cond' must have one value column per conditioning variable and ",
-          "one additional left-limit column per discrete conditioning variable.",
+          "one additional left-limit column per discrete conditioning variable ",
+          "(compact layout), or two columns per conditioning variable ",
+          "(expanded layout).",
           call. = FALSE
         )
+      }
+      if (ncol(u_cond) == expanded_cols) {
+        continuous <- which(vinecop$var_types[conditioning_set] == "c")
+        left_limits <- u_cond[,
+          length(conditioning_set) + continuous,
+          drop = FALSE
+        ]
+        values <- u_cond[, continuous, drop = FALSE]
+        if (!isTRUE(all.equal(left_limits, values))) {
+          stop(
+            "expanded-layout left-limit columns for continuous conditioning ",
+            "variables must equal their value columns.",
+            call. = FALSE
+          )
+        }
       }
     }
 

--- a/R/vinecop_methods.R
+++ b/R/vinecop_methods.R
@@ -13,6 +13,16 @@
 #'   done in parallel on `cores` batches .
 #' @param keep_all if `TRUE`, `dvinecop()` returns additional intermediate
 #'   quantities computed during density evaluation.
+#' @param u_cond optional conditioning values for `rvinecop()`. A vector or
+#'   one-row matrix is repeated `n` times; alternatively, supply an `n`-row
+#'   matrix for observation-specific conditioning values. The first block holds
+#'   the copula-scale values \eqn{F(x)}. For discrete conditioning variables,
+#'   append their left limits \eqn{F(x^-)} in the same relative order. If
+#'   `NULL`, `rvinecop()` performs unconditional simulation.
+#' @param conditioning_set variable indices or names corresponding to the first
+#'   block of `u_cond`. When `NULL`, the columns of `u_cond` correspond to the
+#'   last variables of the current vine order. When supplied, the model is
+#'   transiently reoriented and is not modified.
 #' @details See [vinecop()] for the estimation and construction of vine copula
 #' models.
 #'
@@ -32,8 +42,9 @@
 #'
 #' @return
 #' `dvinecop()` gives the density, `pvinecop()` gives the distribution function,
-#' `rvinecop()` generates random deviates, `scores()` gives the observation-wise
-#' score matrix, and `hessian()` gives the average Hessian matrix.
+#' `rvinecop()` generates unconditional or conditional random deviates,
+#' `scores()` gives the observation-wise score matrix, and `hessian()` gives the
+#' average Hessian matrix.
 #'
 #' If `keep_all = TRUE`, `dvinecop()` returns a list with entries `pdf`,
 #' `pdf_edges`, `hfunc1`, `hfunc2`, `hfunc1_sub`, and `hfunc2_sub`. The `_sub`
@@ -84,6 +95,20 @@
 #'
 #' # simulated data always has uniform margins
 #' pairs(rvinecop(200, vc))
+#'
+#' ## Conditional simulation
+#' vc_cond <- vinecop(u, family = "gaussian", conditioning_set = c(2, 4))
+#' u_cond <- c(0.25, 0.75)
+#' uc <- rvinecop(
+#'   100,
+#'   vc_cond,
+#'   u_cond = u_cond,
+#'   conditioning_set = c(2, 4)
+#' )
+#' stopifnot(
+#'   isTRUE(all.equal(uc[, 2], rep(0.25, 100))),
+#'   isTRUE(all.equal(uc[, 4], rep(0.75, 100)))
+#' )
 #' @rdname vinecop_methods
 #' @export
 dvinecop <- function(u, vinecop, cores = 1, keep_all = FALSE) {
@@ -150,15 +175,65 @@ pvinecop <- function(u, vinecop, n_mc = 10^4, cores = 1) {
 #' Generalized Halton sequence up to dimension 300 and the Generalized Sobol
 #' sequence in higher dimensions (default `qrng = FALSE`).
 #' @export
-rvinecop <- function(n, vinecop, qrng = FALSE, cores = 1) {
+rvinecop <- function(
+  n,
+  vinecop,
+  qrng = FALSE,
+  cores = 1,
+  u_cond = NULL,
+  conditioning_set = NULL
+) {
   assert_that(
-    is.number(n),
+    is.count(n),
     inherits(vinecop, "vinecop_dist"),
     is.flag(qrng),
-    is.number(cores)
+    is.number(cores),
+    cores > 0
   )
 
-  U <- vinecop_sim_cpp(vinecop, n, qrng, cores, get_seeds())
+  n <- as.integer(n)
+  if (is.null(u_cond)) {
+    if (!is.null(conditioning_set) && length(conditioning_set) > 0) {
+      stop("'conditioning_set' requires 'u_cond'.", call. = FALSE)
+    }
+    U <- vinecop_sim_cpp(vinecop, n, qrng, cores, get_seeds())
+  } else {
+    u_cond <- process_conditioning_values(
+      u_cond,
+      n,
+      "u_cond",
+      numeric_only = TRUE
+    )
+    u_cond <- as.matrix(u_cond)
+    storage.mode(u_cond) <- "double"
+
+    conditioning_set <- process_conditioning_set(
+      conditioning_set,
+      vinecop$names,
+      dim(vinecop)[1]
+    )
+    if (length(conditioning_set) > 0) {
+      n_discrete <- sum(vinecop$var_types[conditioning_set] == "d")
+      expected_cols <- length(conditioning_set) + n_discrete
+      if (ncol(u_cond) != expected_cols) {
+        stop(
+          "'u_cond' must have one value column per conditioning variable and ",
+          "one additional left-limit column per discrete conditioning variable.",
+          call. = FALSE
+        )
+      }
+    }
+
+    U <- vinecop_sim_conditional_cpp(
+      vinecop,
+      u_cond,
+      conditioning_set,
+      qrng,
+      cores,
+      get_seeds()
+    )
+  }
+
   if (!is.null(vinecop$names)) {
     colnames(U) <- vinecop$names
   }

--- a/man/vine.Rd
+++ b/man/vine.Rd
@@ -11,7 +11,8 @@ vine(
   copula_controls = list(family_set = "all", structure = NA, par_method = "mle",
     nonpar_method = "constant", mult = 1, selcrit = "aic", psi0 = 0.9, presel = TRUE,
     allow_rotations = TRUE, trunc_lvl = Inf, tree_crit = "tau", threshold = 0, keep_data
-    = FALSE, show_trace = FALSE, cores = 1, tree_algorithm = "mst_prim"),
+    = FALSE, show_trace = FALSE, cores = 1, tree_algorithm = "mst_prim", conditioning_set
+    = NULL),
   weights = numeric(),
   keep_data = FALSE,
   cores = 1

--- a/man/vine_methods.Rd
+++ b/man/vine_methods.Rd
@@ -14,7 +14,7 @@ dvine(x, vine, cores = 1)
 
 pvine(x, vine, n_mc = 10^4, cores = 1)
 
-rvine(n, vine, qrng = FALSE, cores = 1)
+rvine(n, vine, qrng = FALSE, cores = 1, x_cond = NULL, conditioning_set = NULL)
 }
 \arguments{
 \item{x}{evaluation points, either a length d vector or a d-column matrix,
@@ -32,10 +32,21 @@ done in parallel on \code{cores} batches .}
 \item{qrng}{if \code{TRUE}, generates quasi-random numbers using the multivariate
 Generalized Halton sequence up to dimension 300 and the Generalized Sobol
 sequence in higher dimensions (default \code{qrng = FALSE}).}
+
+\item{x_cond}{optional conditioning values for \code{rvine()} on the original
+data scale. A vector or one-row object is repeated \code{n} times;
+alternatively, supply an \code{n}-row matrix or data frame for
+observation-specific conditioning values. If \code{NULL}, \code{rvine()} performs
+unconditional simulation.}
+
+\item{conditioning_set}{variable indices or names corresponding to the
+columns of \code{x_cond}. When \code{NULL}, the columns correspond to the last
+variables of the current copula order. Discrete left limits are computed
+internally from the fitted margins.}
 }
 \value{
 \code{dvine()} gives the density, \code{pvine()} gives the distribution function,
-and \code{rvine()} generates random deviates.
+and \code{rvine()} generates unconditional or conditional random deviates.
 
 The length of the result is determined by \code{n} for \code{rvine()}, and
 the number of rows in \code{u} for the other functions.

--- a/man/vinecop.Rd
+++ b/man/vinecop.Rd
@@ -24,7 +24,8 @@ vinecop(
   vinecop_object = NULL,
   show_trace = FALSE,
   cores = 1,
-  tree_algorithm = "mst_prim"
+  tree_algorithm = "mst_prim",
+  conditioning_set = NULL
 )
 }
 \arguments{
@@ -108,6 +109,12 @@ the sum of the edge weights (i.e., \code{tree_criterion}).
 algorithm to generate a random spanning tree, either with probability
 proportional to the product of the edge weights (weighted) or
 uniformly (unweighted).}
+
+\item{conditioning_set}{variable indices or names to place at the end of the
+vine order. The resulting model can be sampled conditionally with
+\code{\link[=rvinecop]{rvinecop()}} by supplying \code{u_cond}. Conditioning-aware selection requires
+a full, non-truncated vine and an MST tree algorithm (\code{"mst_prim"} or
+\code{"mst_kruskal"}).}
 }
 \value{
 Objects inheriting from \code{vinecop} and \code{vinecop_dist} for \code{\link[=vinecop]{vinecop()}}. In

--- a/man/vinecop_methods.Rd
+++ b/man/vinecop_methods.Rd
@@ -57,8 +57,10 @@ sequence in higher dimensions (default \code{qrng = FALSE}).}
 \item{u_cond}{optional conditioning values for \code{rvinecop()}. A vector or
 one-row matrix is repeated \code{n} times; alternatively, supply an \code{n}-row
 matrix for observation-specific conditioning values. The first block holds
-the copula-scale values \eqn{F(x)}. For discrete conditioning variables,
-append their left limits \eqn{F(x^-)} in the same relative order. If
+the copula-scale values \eqn{F(x)}. The expanded layout appends one
+left-limit column \eqn{F(x^-)} per conditioning variable in the same order;
+columns for continuous variables equal their value columns. In the compact
+layout, the redundant columns for continuous variables are omitted. If
 \code{NULL}, \code{rvinecop()} performs unconditional simulation.}
 
 \item{conditioning_set}{variable indices or names corresponding to the first

--- a/man/vinecop_methods.Rd
+++ b/man/vinecop_methods.Rd
@@ -20,7 +20,14 @@ hessian(u, vinecop, step_wise = TRUE, cores = 1)
 
 pvinecop(u, vinecop, n_mc = 10^4, cores = 1)
 
-rvinecop(n, vinecop, qrng = FALSE, cores = 1)
+rvinecop(
+  n,
+  vinecop,
+  qrng = FALSE,
+  cores = 1,
+  u_cond = NULL,
+  conditioning_set = NULL
+)
 }
 \arguments{
 \item{u}{matrix of evaluation points; must contain at least d columns, where
@@ -46,11 +53,24 @@ step-wise estimation.}
 \item{qrng}{if \code{TRUE}, generates quasi-random numbers using the multivariate
 Generalized Halton sequence up to dimension 300 and the Generalized Sobol
 sequence in higher dimensions (default \code{qrng = FALSE}).}
+
+\item{u_cond}{optional conditioning values for \code{rvinecop()}. A vector or
+one-row matrix is repeated \code{n} times; alternatively, supply an \code{n}-row
+matrix for observation-specific conditioning values. The first block holds
+the copula-scale values \eqn{F(x)}. For discrete conditioning variables,
+append their left limits \eqn{F(x^-)} in the same relative order. If
+\code{NULL}, \code{rvinecop()} performs unconditional simulation.}
+
+\item{conditioning_set}{variable indices or names corresponding to the first
+block of \code{u_cond}. When \code{NULL}, the columns of \code{u_cond} correspond to the
+last variables of the current vine order. When supplied, the model is
+transiently reoriented and is not modified.}
 }
 \value{
 \code{dvinecop()} gives the density, \code{pvinecop()} gives the distribution function,
-\code{rvinecop()} generates random deviates, \code{scores()} gives the observation-wise
-score matrix, and \code{hessian()} gives the average Hessian matrix.
+\code{rvinecop()} generates unconditional or conditional random deviates,
+\code{scores()} gives the observation-wise score matrix, and \code{hessian()} gives the
+average Hessian matrix.
 
 If \code{keep_all = TRUE}, \code{dvinecop()} returns a list with entries \code{pdf},
 \code{pdf_edges}, \code{hfunc1}, \code{hfunc2}, \code{hfunc1_sub}, and \code{hfunc2_sub}. The \verb{_sub}
@@ -121,6 +141,20 @@ pvinecop(u_disc[1:5, ], vc)
 
 # simulated data always has uniform margins
 pairs(rvinecop(200, vc))
+
+## Conditional simulation
+vc_cond <- vinecop(u, family = "gaussian", conditioning_set = c(2, 4))
+u_cond <- c(0.25, 0.75)
+uc <- rvinecop(
+  100,
+  vc_cond,
+  u_cond = u_cond,
+  conditioning_set = c(2, 4)
+)
+stopifnot(
+  isTRUE(all.equal(uc[, 2], rep(0.25, 100))),
+  isTRUE(all.equal(uc[, 4], rep(0.75, 100)))
+)
 }
 \seealso{
 \code{\link[=vinecop_dist]{vinecop_dist()}}, \code{\link[=vinecop]{vinecop()}}, \code{\link[=plot.vinecop]{plot.vinecop()}}, \code{\link[=contour.vinecop]{contour.vinecop()}}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -288,13 +288,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // vinecop_sim_conditional_cpp
-Eigen::MatrixXd vinecop_sim_conditional_cpp(const Rcpp::List& vinecop_r, Eigen::MatrixXd u_cond, const std::vector<size_t>& conditioning_set, const bool qrng, const size_t cores, const std::vector<int>& seeds);
+Eigen::MatrixXd vinecop_sim_conditional_cpp(const Rcpp::List& vinecop_r, const Eigen::MatrixXd& u_cond, const std::vector<size_t>& conditioning_set, const bool qrng, const size_t cores, const std::vector<int>& seeds);
 RcppExport SEXP _rvinecopulib_vinecop_sim_conditional_cpp(SEXP vinecop_rSEXP, SEXP u_condSEXP, SEXP conditioning_setSEXP, SEXP qrngSEXP, SEXP coresSEXP, SEXP seedsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::List& >::type vinecop_r(vinecop_rSEXP);
-    Rcpp::traits::input_parameter< Eigen::MatrixXd >::type u_cond(u_condSEXP);
+    Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type u_cond(u_condSEXP);
     Rcpp::traits::input_parameter< const std::vector<size_t>& >::type conditioning_set(conditioning_setSEXP);
     Rcpp::traits::input_parameter< const bool >::type qrng(qrngSEXP);
     Rcpp::traits::input_parameter< const size_t >::type cores(coresSEXP);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -287,6 +287,22 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// vinecop_sim_conditional_cpp
+Eigen::MatrixXd vinecop_sim_conditional_cpp(const Rcpp::List& vinecop_r, Eigen::MatrixXd u_cond, const std::vector<size_t>& conditioning_set, const bool qrng, const size_t cores, const std::vector<int>& seeds);
+RcppExport SEXP _rvinecopulib_vinecop_sim_conditional_cpp(SEXP vinecop_rSEXP, SEXP u_condSEXP, SEXP conditioning_setSEXP, SEXP qrngSEXP, SEXP coresSEXP, SEXP seedsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::List& >::type vinecop_r(vinecop_rSEXP);
+    Rcpp::traits::input_parameter< Eigen::MatrixXd >::type u_cond(u_condSEXP);
+    Rcpp::traits::input_parameter< const std::vector<size_t>& >::type conditioning_set(conditioning_setSEXP);
+    Rcpp::traits::input_parameter< const bool >::type qrng(qrngSEXP);
+    Rcpp::traits::input_parameter< const size_t >::type cores(coresSEXP);
+    Rcpp::traits::input_parameter< const std::vector<int>& >::type seeds(seedsSEXP);
+    rcpp_result_gen = Rcpp::wrap(vinecop_sim_conditional_cpp(vinecop_r, u_cond, conditioning_set, qrng, cores, seeds));
+    return rcpp_result_gen;
+END_RCPP
+}
 // vinecop_pdf_cpp
 Eigen::VectorXd vinecop_pdf_cpp(const Eigen::MatrixXd& u, const Rcpp::List& vinecop_r, size_t cores);
 RcppExport SEXP _rvinecopulib_vinecop_pdf_cpp(SEXP uSEXP, SEXP vinecop_rSEXP, SEXP coresSEXP) {
@@ -357,8 +373,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // vinecop_select_cpp
-Rcpp::List vinecop_select_cpp(const Eigen::MatrixXd& data, Rcpp::List& structure, std::vector<std::string> family_set, std::string par_method, std::string nonpar_method, double mult, int truncation_level, std::string tree_criterion, double threshold, std::string selection_criterion, const Eigen::VectorXd& weights, double psi0, bool select_truncation_level, bool select_threshold, bool preselect_families, bool select_families, bool allow_rotations, bool show_trace, size_t num_threads, std::vector<std::string> var_types, std::string tree_algorithm, std::vector<int> seeds);
-RcppExport SEXP _rvinecopulib_vinecop_select_cpp(SEXP dataSEXP, SEXP structureSEXP, SEXP family_setSEXP, SEXP par_methodSEXP, SEXP nonpar_methodSEXP, SEXP multSEXP, SEXP truncation_levelSEXP, SEXP tree_criterionSEXP, SEXP thresholdSEXP, SEXP selection_criterionSEXP, SEXP weightsSEXP, SEXP psi0SEXP, SEXP select_truncation_levelSEXP, SEXP select_thresholdSEXP, SEXP preselect_familiesSEXP, SEXP select_familiesSEXP, SEXP allow_rotationsSEXP, SEXP show_traceSEXP, SEXP num_threadsSEXP, SEXP var_typesSEXP, SEXP tree_algorithmSEXP, SEXP seedsSEXP) {
+Rcpp::List vinecop_select_cpp(const Eigen::MatrixXd& data, Rcpp::List& structure, std::vector<std::string> family_set, std::string par_method, std::string nonpar_method, double mult, int truncation_level, std::string tree_criterion, double threshold, std::string selection_criterion, const Eigen::VectorXd& weights, double psi0, bool select_truncation_level, bool select_threshold, bool preselect_families, bool select_families, bool allow_rotations, bool show_trace, size_t num_threads, std::vector<std::string> var_types, std::string tree_algorithm, std::vector<int> seeds, std::vector<size_t> conditioning_set);
+RcppExport SEXP _rvinecopulib_vinecop_select_cpp(SEXP dataSEXP, SEXP structureSEXP, SEXP family_setSEXP, SEXP par_methodSEXP, SEXP nonpar_methodSEXP, SEXP multSEXP, SEXP truncation_levelSEXP, SEXP tree_criterionSEXP, SEXP thresholdSEXP, SEXP selection_criterionSEXP, SEXP weightsSEXP, SEXP psi0SEXP, SEXP select_truncation_levelSEXP, SEXP select_thresholdSEXP, SEXP preselect_familiesSEXP, SEXP select_familiesSEXP, SEXP allow_rotationsSEXP, SEXP show_traceSEXP, SEXP num_threadsSEXP, SEXP var_typesSEXP, SEXP tree_algorithmSEXP, SEXP seedsSEXP, SEXP conditioning_setSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -384,7 +400,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::vector<std::string> >::type var_types(var_typesSEXP);
     Rcpp::traits::input_parameter< std::string >::type tree_algorithm(tree_algorithmSEXP);
     Rcpp::traits::input_parameter< std::vector<int> >::type seeds(seedsSEXP);
-    rcpp_result_gen = Rcpp::wrap(vinecop_select_cpp(data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds));
+    Rcpp::traits::input_parameter< std::vector<size_t> >::type conditioning_set(conditioning_setSEXP);
+    rcpp_result_gen = Rcpp::wrap(vinecop_select_cpp(data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds, conditioning_set));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -451,12 +468,13 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rvinecopulib_vinecop_inverse_rosenblatt_cpp", (DL_FUNC) &_rvinecopulib_vinecop_inverse_rosenblatt_cpp, 3},
     {"_rvinecopulib_vinecop_rosenblatt_cpp", (DL_FUNC) &_rvinecopulib_vinecop_rosenblatt_cpp, 5},
     {"_rvinecopulib_vinecop_sim_cpp", (DL_FUNC) &_rvinecopulib_vinecop_sim_cpp, 5},
+    {"_rvinecopulib_vinecop_sim_conditional_cpp", (DL_FUNC) &_rvinecopulib_vinecop_sim_conditional_cpp, 6},
     {"_rvinecopulib_vinecop_pdf_cpp", (DL_FUNC) &_rvinecopulib_vinecop_pdf_cpp, 3},
     {"_rvinecopulib_vinecop_pdf_full_cpp", (DL_FUNC) &_rvinecopulib_vinecop_pdf_full_cpp, 3},
     {"_rvinecopulib_vinecop_cdf_cpp", (DL_FUNC) &_rvinecopulib_vinecop_cdf_cpp, 5},
     {"_rvinecopulib_vinecop_scores_cpp", (DL_FUNC) &_rvinecopulib_vinecop_scores_cpp, 4},
     {"_rvinecopulib_vinecop_hessian_cpp", (DL_FUNC) &_rvinecopulib_vinecop_hessian_cpp, 4},
-    {"_rvinecopulib_vinecop_select_cpp", (DL_FUNC) &_rvinecopulib_vinecop_select_cpp, 22},
+    {"_rvinecopulib_vinecop_select_cpp", (DL_FUNC) &_rvinecopulib_vinecop_select_cpp, 23},
     {"_rvinecopulib_vinecop_fit_cpp", (DL_FUNC) &_rvinecopulib_vinecop_fit_cpp, 10},
     {"_rvinecopulib_fit_margins_cpp", (DL_FUNC) &_rvinecopulib_fit_margins_cpp, 9},
     {NULL, NULL, 0}

--- a/src/vinecopulib-interface.cpp
+++ b/src/vinecopulib-interface.cpp
@@ -263,44 +263,18 @@ Eigen::MatrixXd vinecop_sim_cpp(const Rcpp::List& vinecop_r,
 // [[Rcpp::export()]]
 Eigen::MatrixXd vinecop_sim_conditional_cpp(
   const Rcpp::List& vinecop_r,
-  Eigen::MatrixXd u_cond,
+  const Eigen::MatrixXd& u_cond,
   const std::vector<size_t>& conditioning_set,
   const bool qrng,
   const size_t cores,
   const std::vector<int>& seeds)
 {
   Vinecop vinecop_cpp = vinecop_wrap(vinecop_r);
-  if (!conditioning_set.empty()) {
-    const auto var_types = vinecop_cpp.get_var_types();
-    const size_t k = conditioning_set.size();
-    vinecop_cpp.reorient(conditioning_set);
-    const auto order = vinecop_cpp.get_order();
-    const size_t d = order.size();
-
-    Eigen::MatrixXd u_ordered(u_cond.rows(), u_cond.cols());
-    size_t output_discrete = 0;
-    for (size_t i = 0; i < k; ++i) {
-      const size_t variable = order[d - k + i];
-      const auto input_it = std::find(
-        conditioning_set.begin(), conditioning_set.end(), variable);
-      const size_t input_position = static_cast<size_t>(
-        std::distance(conditioning_set.begin(), input_it));
-      u_ordered.col(i) = u_cond.col(input_position);
-
-      if (var_types[variable - 1] == "d") {
-        size_t input_discrete = 0;
-        for (size_t j = 0; j < input_position; ++j) {
-          input_discrete += var_types[conditioning_set[j] - 1] == "d";
-        }
-        u_ordered.col(k + output_discrete) =
-          u_cond.col(k + input_discrete);
-        ++output_discrete;
-      }
-    }
-    u_cond = std::move(u_ordered);
+  if (conditioning_set.empty()) {
+    return vinecop_cpp.simulate_conditional(u_cond, qrng, cores, seeds);
   }
-
-  return vinecop_cpp.simulate_conditional(u_cond, qrng, cores, seeds);
+  return vinecop_cpp.simulate_conditional(
+    u_cond, conditioning_set, qrng, cores, seeds);
 }
 
 // [[Rcpp::export()]]

--- a/src/vinecopulib-interface.cpp
+++ b/src/vinecopulib-interface.cpp
@@ -1,6 +1,8 @@
 #include "vinecopulib-wrappers.hpp"
 #include "kde1d-wrappers.hpp"
 
+#include <algorithm>
+
 using namespace vinecopulib;
 
 inline Eigen::MatrixXd get_bicop_parameters(const Rcpp::List& bicop_r)
@@ -259,6 +261,49 @@ Eigen::MatrixXd vinecop_sim_cpp(const Rcpp::List& vinecop_r,
 }
 
 // [[Rcpp::export()]]
+Eigen::MatrixXd vinecop_sim_conditional_cpp(
+  const Rcpp::List& vinecop_r,
+  Eigen::MatrixXd u_cond,
+  const std::vector<size_t>& conditioning_set,
+  const bool qrng,
+  const size_t cores,
+  const std::vector<int>& seeds)
+{
+  Vinecop vinecop_cpp = vinecop_wrap(vinecop_r);
+  if (!conditioning_set.empty()) {
+    const auto var_types = vinecop_cpp.get_var_types();
+    const size_t k = conditioning_set.size();
+    vinecop_cpp.reorient(conditioning_set);
+    const auto order = vinecop_cpp.get_order();
+    const size_t d = order.size();
+
+    Eigen::MatrixXd u_ordered(u_cond.rows(), u_cond.cols());
+    size_t output_discrete = 0;
+    for (size_t i = 0; i < k; ++i) {
+      const size_t variable = order[d - k + i];
+      const auto input_it = std::find(
+        conditioning_set.begin(), conditioning_set.end(), variable);
+      const size_t input_position = static_cast<size_t>(
+        std::distance(conditioning_set.begin(), input_it));
+      u_ordered.col(i) = u_cond.col(input_position);
+
+      if (var_types[variable - 1] == "d") {
+        size_t input_discrete = 0;
+        for (size_t j = 0; j < input_position; ++j) {
+          input_discrete += var_types[conditioning_set[j] - 1] == "d";
+        }
+        u_ordered.col(k + output_discrete) =
+          u_cond.col(k + input_discrete);
+        ++output_discrete;
+      }
+    }
+    u_cond = std::move(u_ordered);
+  }
+
+  return vinecop_cpp.simulate_conditional(u_cond, qrng, cores, seeds);
+}
+
+// [[Rcpp::export()]]
 Eigen::VectorXd vinecop_pdf_cpp(const Eigen::MatrixXd& u,
                                 const Rcpp::List& vinecop_r,
                                 size_t cores)
@@ -355,7 +400,8 @@ Rcpp::List vinecop_select_cpp(const Eigen::MatrixXd &data,
                               size_t num_threads,
                               std::vector<std::string> var_types,
                               std::string tree_algorithm,
-                              std::vector<int> seeds)
+                              std::vector<int> seeds,
+                              std::vector<size_t> conditioning_set)
 {
   std::vector<BicopFamily> fam_set(family_set.size());
   for (unsigned int fam = 0; fam < fam_set.size(); ++fam) {
@@ -382,6 +428,7 @@ Rcpp::List vinecop_select_cpp(const Eigen::MatrixXd &data,
   fit_controls.set_show_trace(show_trace);
   fit_controls.set_tree_algorithm(tree_algorithm);
   fit_controls.set_seeds(seeds);
+  fit_controls.set_conditioning_set(conditioning_set);
 
   Vinecop vinecop_cpp(rvine_structure_wrap(structure, false));
   vinecop_cpp.set_var_types(var_types);
@@ -454,4 +501,3 @@ std::vector<Rcpp::List> fit_margins_cpp(const Eigen::MatrixXd& data,
   }
   return fits_r;
 }
-

--- a/tests/testthat/test_discrete.R
+++ b/tests/testthat/test_discrete.R
@@ -136,3 +136,32 @@ test_that("vine works", {
   pvine(x, fit)
   rvine(10, fit)
 })
+
+test_that("rvine computes discrete conditioning limits internally", {
+  n <- 30
+  x <- data.frame(
+    x1 = rnorm(n),
+    x2 = ordered(sample(5, n, TRUE), 1:5),
+    x3 = rnorm(n)
+  )
+  fit <- vine(
+    x,
+    copula_controls = list(
+      family_set = "indep",
+      conditioning_set = c("x3", "x2")
+    )
+  )
+  x_cond <- data.frame(
+    x3 = 1.25,
+    x2 = ordered(3, levels = 1:5)
+  )
+
+  sim <- rvine(
+    20,
+    fit,
+    x_cond = x_cond,
+    conditioning_set = c("x3", "x2")
+  )
+  expect_equal(sim$x3, rep(1.25, 20))
+  expect_identical(sim$x2, ordered(rep(3, 20), levels = 1:5))
+})

--- a/tests/testthat/test_discrete.R
+++ b/tests/testthat/test_discrete.R
@@ -164,4 +164,12 @@ test_that("rvine computes discrete conditioning limits internally", {
   )
   expect_equal(sim$x3, rep(1.25, 20))
   expect_identical(sim$x2, ordered(rep(3, 20), levels = 1:5))
+
+  sim_factor <- rvine(
+    5,
+    fit,
+    x_cond = ordered(3, levels = 1:5),
+    conditioning_set = "x2"
+  )
+  expect_identical(sim_factor$x2, ordered(rep(3, 5), levels = 1:5))
 })

--- a/tests/testthat/test_vine.R
+++ b/tests/testthat/test_vine.R
@@ -65,9 +65,6 @@ test_that("truncation works", {
 })
 
 test_that("conditioning-aware selection is passed to the copula fit", {
-  rng_state <- .Random.seed
-  on.exit(assign(".Random.seed", rng_state, envir = globalenv()), add = TRUE)
-
   u_named <- as.data.frame(u[, 1:4])
   fit_conditioned <- vine(
     u_named,
@@ -122,9 +119,9 @@ test_that("d = 1 works", {
 
 test_that("discrete variables work", {
   x <- data.frame(
-    x1 = sample(1:4, 50, replace = TRUE),
-    x2 = rnorm(50),
-    x3 = rbinom(50, 3, 0.5)
+    x1 = rep(1:4, length.out = 50),
+    x2 = qnorm((seq_len(50) - 0.5) / 50),
+    x3 = rep(0:3, length.out = 50)
   )
 
   expect_no_error(
@@ -144,7 +141,10 @@ test_that("discrete variables work", {
   expect_equal(fit$margins[[1]]$type, "discrete")
   expect_equal(fit$copula$var_types, c("d", "c", "c"))
   expect_equiv(dvine(x, fit), dvine(x2, fit2))
-  expect_equiv(pvine(x, fit), pvine(x2, fit2), tol = 1e-2)
+  set.seed(42)
+  p <- pvine(x, fit)
+  set.seed(42)
+  expect_equiv(p, pvine(x2, fit2))
   expect_equal(colnames(rvine(20, fit)), c("x1", "x2", "x3"))
 
   expect_no_error(fit <- vine(x, margin = list(type = c("d", "c", "zi"))))

--- a/tests/testthat/test_vine.R
+++ b/tests/testthat/test_vine.R
@@ -65,6 +65,9 @@ test_that("truncation works", {
 })
 
 test_that("conditioning-aware selection is passed to the copula fit", {
+  rng_state <- .Random.seed
+  on.exit(assign(".Random.seed", rng_state, envir = globalenv()), add = TRUE)
+
   u_named <- as.data.frame(u[, 1:4])
   fit_conditioned <- vine(
     u_named,

--- a/tests/testthat/test_vine.R
+++ b/tests/testthat/test_vine.R
@@ -121,7 +121,7 @@ test_that("discrete variables work", {
   x <- data.frame(
     x1 = rep(1:4, length.out = 50),
     x2 = qnorm((seq_len(50) - 0.5) / 50),
-    x3 = rep(0:3, length.out = 50)
+    x3 = floor(((seq_len(50) * 17) %% 53) / 53 * 4)
   )
 
   expect_no_error(

--- a/tests/testthat/test_vine.R
+++ b/tests/testthat/test_vine.R
@@ -64,6 +64,26 @@ test_that("truncation works", {
   expect_silent(rvine(50, fit_truncated))
 })
 
+test_that("conditioning-aware selection is passed to the copula fit", {
+  u_named <- as.data.frame(u[, 1:4])
+  fit_conditioned <- vine(
+    u_named,
+    copula_controls = list(
+      family_set = "indep",
+      conditioning_set = c("V2", "V4")
+    )
+  )
+
+  expect_identical(
+    fit_conditioned$copula$controls$conditioning_set,
+    c(2L, 4L)
+  )
+  expect_equal(
+    sort(tail(fit_conditioned$copula$structure$order, 2)),
+    c(2L, 4L)
+  )
+})
+
 test_that("margins_controls works", {
   fit_mult <- vine(u, margins_controls = list(mult = 2))
   expect_eql(

--- a/tests/testthat/test_vine_dist.R
+++ b/tests/testthat/test_vine_dist.R
@@ -57,6 +57,29 @@ test_that("rvine performs conditional simulation on the data scale", {
     rvine(5, vc_cond, conditioning_set = "a"),
     "requires 'x_cond'"
   )
+  expect_error(rvine(1.5, vc_cond), "not a count")
+  expect_error(rvine(5, vc_cond, qrng = 1), "not a flag")
+  expect_error(rvine(5, vc_cond, cores = 0), "not greater than 0")
+  expect_error(
+    rvine(5, vc_cond, x_cond = list(0.5), conditioning_set = "a"),
+    "must be a vector, matrix, or data frame"
+  )
+  expect_error(
+    rvine(5, vc_cond, x_cond = matrix(0.5, 2, 1), conditioning_set = "a"),
+    "must have one or 'n' rows"
+  )
+  expect_error(
+    rvine(5, vc_cond, x_cond = c(0.5, 0.5), conditioning_set = "a"),
+    "one column per conditioning variable"
+  )
+  expect_error(
+    rvine(5, vc_cond, x_cond = matrix(0.5, 1, 3)),
+    "between 1 and d - 1 columns"
+  )
+  expect_error(
+    rvine(5, vc_cond, x_cond = matrix(numeric(), 5, 0)),
+    "between 1 and d - 1 columns"
+  )
 })
 
 test_that("constructor catches wrong input", {

--- a/tests/testthat/test_vine_dist.R
+++ b/tests/testthat/test_vine_dist.R
@@ -28,6 +28,37 @@ test_that("d/p/r- functions work", {
   expect_lte(max(pvine(u, vc, 100)), 1)
 })
 
+test_that("rvine performs conditional simulation on the data scale", {
+  indep <- bicop_dist()
+  vc_cond <- vine_dist(
+    rep(list(list(distr = "norm")), 3),
+    list(list(indep, indep), list(indep)),
+    dvine_structure(1:3)
+  )
+  vc_cond$names <- vc_cond$copula$names <- c("a", "b", "c")
+
+  x <- rvine(
+    10,
+    vc_cond,
+    x_cond = c(1.25, -0.5),
+    conditioning_set = c("c", "b")
+  )
+  expect_identical(dim(x), c(10L, 3L))
+  expect_identical(colnames(x), c("a", "b", "c"))
+  expect_equal(x[, "c"], rep(1.25, 10))
+  expect_equal(x[, "b"], rep(-0.5, 10))
+
+  x_obs <- cbind(seq(-1, 1, length.out = 5), rep(0.25, 5))
+  x <- rvine(5, vc_cond, x_cond = x_obs)
+  expect_equal(x[, "b"], x_obs[, 1])
+  expect_equal(x[, "c"], x_obs[, 2])
+
+  expect_error(
+    rvine(5, vc_cond, conditioning_set = "a"),
+    "requires 'x_cond'"
+  )
+})
+
 test_that("constructor catches wrong input", {
   # missing margin name
   expect_error(vine_dist(list(stupid = "norm"), pcs, mat))

--- a/tests/testthat/test_vinecop.R
+++ b/tests/testthat/test_vinecop.R
@@ -167,6 +167,44 @@ test_that("MST algorithms behave as expected", {
   expect_equal(length(unique_structures), 10)
 })
 
+test_that("conditioning-aware selection is exposed through the R controls", {
+  u_cond <- matrix(runif(400), 100, 4)
+  colnames(u_cond) <- letters[1:4]
+  fit_cond <- vinecop(
+    u_cond,
+    family_set = "indep",
+    conditioning_set = c("b", "d")
+  )
+
+  expect_identical(fit_cond$controls$conditioning_set, c(2L, 4L))
+  expect_equal(sort(tail(fit_cond$structure$order, 2)), c(2L, 4L))
+
+  expect_error(
+    vinecop(u_cond, conditioning_set = c("b", "b")),
+    "must not contain duplicates"
+  )
+  expect_error(
+    vinecop(unname(u_cond), conditioning_set = "b"),
+    "requires named variables"
+  )
+  expect_error(
+    vinecop(u_cond, conditioning_set = 2, trunc_lvl = 1),
+    "requires a non-truncated vine"
+  )
+  expect_error(
+    vinecop(
+      u_cond,
+      conditioning_set = 2,
+      tree_algorithm = "random_weighted"
+    ),
+    "requires 'tree_algorithm'"
+  )
+  expect_error(
+    vinecop(u_cond, conditioning_set = 2, vinecop_object = fit_cond),
+    "cannot be used when refitting"
+  )
+})
+
 test_that("d = 1 works", {
   vc <- vinecop(runif(20), structure = rvine_structure(1))
   vc2 <- vinecop(runif(20))

--- a/tests/testthat/test_vinecop.R
+++ b/tests/testthat/test_vinecop.R
@@ -184,8 +184,34 @@ test_that("conditioning-aware selection is exposed through the R controls", {
     "must not contain duplicates"
   )
   expect_error(
+    vinecop(u_cond, conditioning_set = "unknown"),
+    "unknown variable names"
+  )
+  u_duplicated_names <- u_cond
+  colnames(u_duplicated_names)[2] <- colnames(u_duplicated_names)[1]
+  expect_error(
+    vinecop(u_duplicated_names, conditioning_set = "a"),
+    "requires unique variable names"
+  )
+  expect_error(
     vinecop(unname(u_cond), conditioning_set = "b"),
     "requires named variables"
+  )
+  for (invalid_set in list(TRUE, NA_real_, Inf, 1.5)) {
+    expect_error(
+      vinecop(u_cond, conditioning_set = invalid_set),
+      "must contain variable indices or names"
+    )
+  }
+  for (invalid_set in list(0, 5)) {
+    expect_error(
+      vinecop(u_cond, conditioning_set = invalid_set),
+      "indices must be between 1 and d"
+    )
+  }
+  expect_error(
+    vinecop(u_cond, conditioning_set = 1:4),
+    "at most d - 1 variables"
   )
   expect_error(
     vinecop(u_cond, conditioning_set = 2, trunc_lvl = 1),

--- a/tests/testthat/test_vinecop_dist.R
+++ b/tests/testthat/test_vinecop_dist.R
@@ -78,6 +78,112 @@ test_that("d/p/r- functions work", {
   expect_lte(max(pvinecop(u, vc, 100)), 1)
 })
 
+test_that("conditional simulation handles R-side ordering and recycling", {
+  indep <- bicop_dist()
+  pcs_indep <- list(
+    rep(list(indep), 3),
+    rep(list(indep), 2),
+    list(indep)
+  )
+  vc_cond <- vinecop_dist(pcs_indep, dvine_structure(1:4))
+  vc_cond$names <- letters[1:4]
+  structure_before <- vc_cond$structure
+
+  # Values follow the explicitly supplied set order (4, 3), even though the
+  # current tail order is (3, 4).
+  set.seed(12)
+  u <- rvinecop(
+    20,
+    vc_cond,
+    u_cond = c(0.8, 0.2),
+    conditioning_set = c("d", "c")
+  )
+  expect_equal(dim(u), c(20L, 4L))
+  expect_identical(colnames(u), letters[1:4])
+  expect_equal(u[, 4], rep(0.8, 20))
+  expect_equal(u[, 3], rep(0.2, 20))
+  expect_identical(vc_cond$structure, structure_before)
+
+  set.seed(12)
+  u_parallel <- rvinecop(
+    20,
+    vc_cond,
+    u_cond = c(0.8, 0.2),
+    conditioning_set = c("d", "c"),
+    cores = 2
+  )
+  expect_equal(u_parallel, u)
+
+  # Observation-specific conditions are accepted without recycling.
+  u_cond <- cbind(seq(0.1, 0.5, length.out = 5), rep(0.7, 5))
+  u_obs <- rvinecop(5, vc_cond, u_cond = u_cond)
+  expect_equal(u_obs[, 3], u_cond[, 1])
+  expect_equal(u_obs[, 4], u_cond[, 2])
+
+  # A different admissible set is handled by transient reorientation.
+  u_reoriented <- rvinecop(
+    5,
+    vc_cond,
+    u_cond = 0.35,
+    conditioning_set = "a"
+  )
+  expect_equal(u_reoriented[, 1], rep(0.35, 5))
+
+  expect_error(
+    rvinecop(5, vc_cond, u_cond = matrix(0.5, 2, 2)),
+    "must have one or 'n' rows"
+  )
+  expect_error(
+    rvinecop(
+      5,
+      vc_cond,
+      u_cond = c(0.2, 0.3),
+      conditioning_set = "a"
+    ),
+    "one value column per conditioning variable"
+  )
+  expect_error(
+    rvinecop(5, vc_cond, conditioning_set = "a"),
+    "requires 'u_cond'"
+  )
+})
+
+test_that("conditional simulation accepts discrete left limits", {
+  indep <- bicop_dist()
+  pcs_indep <- list(
+    rep(list(indep), 3),
+    rep(list(indep), 2),
+    list(indep)
+  )
+  vc_disc <- vinecop_dist(
+    pcs_indep,
+    dvine_structure(1:4),
+    var_types = c("c", "c", "d", "d")
+  )
+  vc_disc$names <- letters[1:4]
+
+  # Layout in the supplied set order (4, 3): F4, F3, F4-, F3-.
+  u <- rvinecop(
+    20,
+    vc_disc,
+    u_cond = c(0.8, 0.7, 0.6, 0.5),
+    conditioning_set = c("d", "c")
+  )
+  expect_equal(dim(u), c(20L, 4L))
+  expect_true(all(u[, 4] >= 0.6))
+  expect_true(all(u[, 4] <= 0.8))
+
+  expect_error(
+    rvinecop(
+      5,
+      vc_disc,
+      u_cond = c(0.8, 0.7),
+      conditioning_set = c(4, 3)
+    ),
+    "additional left-limit column"
+  )
+})
+
 test_that("scores and hessian work", {
   u <- rvinecop(10, vc)
   expect_silent(s <- scores(u, vc))

--- a/tests/testthat/test_vinecop_dist.R
+++ b/tests/testthat/test_vinecop_dist.R
@@ -146,6 +146,21 @@ test_that("conditional simulation handles R-side ordering and recycling", {
     rvinecop(5, vc_cond, conditioning_set = "a"),
     "requires 'u_cond'"
   )
+  expect_error(rvinecop(1.5, vc_cond), "not a count")
+  expect_error(rvinecop(5, vc_cond, qrng = 1), "not a flag")
+  expect_error(rvinecop(5, vc_cond, cores = 0), "not greater than 0")
+  expect_error(
+    rvinecop(5, vc_cond, u_cond = list(0.5)),
+    "must be a vector, matrix, or data frame"
+  )
+  expect_error(
+    rvinecop(5, vc_cond, u_cond = data.frame(value = "a")),
+    "must be numeric"
+  )
+  expect_error(
+    rvinecop(5, vc_cond, u_cond = 1.2, conditioning_set = "a"),
+    "all data must be contained"
+  )
 })
 
 test_that("conditional simulation accepts discrete left limits", {
@@ -181,6 +196,15 @@ test_that("conditional simulation accepts discrete left limits", {
       conditioning_set = c(4, 3)
     ),
     "additional left-limit column"
+  )
+  expect_error(
+    rvinecop(
+      5,
+      vc_disc,
+      u_cond = c(0.7, 0.8),
+      conditioning_set = 4
+    ),
+    "left-limit columns.*must not exceed"
   )
 })
 

--- a/tests/testthat/test_vinecop_dist.R
+++ b/tests/testthat/test_vinecop_dist.R
@@ -140,7 +140,7 @@ test_that("conditional simulation handles R-side ordering and recycling", {
       u_cond = c(0.2, 0.3),
       conditioning_set = "a"
     ),
-    "one value column per conditioning variable"
+    "continuous conditioning variables"
   )
   expect_error(
     rvinecop(5, vc_cond, conditioning_set = "a"),
@@ -163,6 +163,53 @@ test_that("conditional simulation handles R-side ordering and recycling", {
   )
 })
 
+test_that("conditional simulation is synchronized with the R seed", {
+  indep <- bicop_dist()
+  vc_cond <- vinecop_dist(
+    list(rep(list(indep), 2), list(indep)),
+    dvine_structure(1:3)
+  )
+
+  for (use_qrng in c(FALSE, TRUE)) {
+    set.seed(314)
+    u1 <- rvinecop(
+      25,
+      vc_cond,
+      qrng = use_qrng,
+      u_cond = 0.4,
+      conditioning_set = 3
+    )
+    state_after <- .Random.seed
+
+    set.seed(314)
+    u2 <- rvinecop(
+      25,
+      vc_cond,
+      qrng = use_qrng,
+      u_cond = 0.4,
+      conditioning_set = 3
+    )
+    expect_identical(u2, u1)
+    expect_identical(.Random.seed, state_after)
+
+    # get_seeds() advances R's RNG by exactly its 20 seed draws; the backend
+    # consumes only the resulting C++ seeds and never touches R's RNG directly.
+    set.seed(314)
+    runif(20)
+    expect_identical(.Random.seed, state_after)
+
+    set.seed(315)
+    u3 <- rvinecop(
+      25,
+      vc_cond,
+      qrng = use_qrng,
+      u_cond = 0.4,
+      conditioning_set = 3
+    )
+    expect_false(identical(u3[, 1:2], u1[, 1:2]))
+  }
+})
+
 test_that("conditional simulation accepts discrete left limits", {
   indep <- bicop_dist()
   pcs_indep <- list(
@@ -173,20 +220,31 @@ test_that("conditional simulation accepts discrete left limits", {
   vc_disc <- vinecop_dist(
     pcs_indep,
     dvine_structure(1:4),
-    var_types = c("c", "c", "d", "d")
+    var_types = c("c", "c", "c", "d")
   )
   vc_disc$names <- letters[1:4]
 
-  # Layout in the supplied set order (4, 3): F4, F3, F4-, F3-.
-  u <- rvinecop(
+  # Expanded layout in the supplied set order (4, 3): F4, F3, F4-, F3-.
+  set.seed(12)
+  u_expanded <- rvinecop(
     20,
     vc_disc,
-    u_cond = c(0.8, 0.7, 0.6, 0.5),
+    u_cond = c(0.8, 0.7, 0.6, 0.7),
     conditioning_set = c("d", "c")
   )
-  expect_equal(dim(u), c(20L, 4L))
-  expect_true(all(u[, 4] >= 0.6))
-  expect_true(all(u[, 4] <= 0.8))
+  # Compact layout omits the redundant F3- column.
+  set.seed(12)
+  u_compact <- rvinecop(
+    20,
+    vc_disc,
+    u_cond = c(0.8, 0.7, 0.6),
+    conditioning_set = c("d", "c")
+  )
+  expect_identical(u_expanded, u_compact)
+  expect_equal(dim(u_expanded), c(20L, 4L))
+  expect_true(all(u_expanded[, 4] >= 0.6))
+  expect_true(all(u_expanded[, 4] <= 0.8))
+  expect_equal(u_expanded[, 3], rep(0.7, 20))
 
   expect_error(
     rvinecop(


### PR DESCRIPTION
## Summary

This adds the R frontend for conditional simulation and is stacked on #328, which vendors the required vinecopulib 1.0 backend APIs.

## API changes and decisions

- `vinecop()` accepts `conditioning_set`, specified by 1-based variable indices or variable names. During structure selection these variables are placed at the tail of the vine order so the fitted model supports conditional simulation.
- `vine()` exposes the same option through `copula_controls$conditioning_set`. Variable names are preserved through the pseudo-observation transformation.
- Conditional simulation is integrated into the existing random-generation functions instead of adding separate public functions:
  - `rvinecop(..., u_cond = NULL, conditioning_set = NULL)` accepts copula-scale conditions.
  - `rvine(..., x_cond = NULL, conditioning_set = NULL)` accepts conditions on the original data scale.
  - Both functions remain unconditional by default, and the new arguments are appended to preserve existing positional calls.
- A vector or one-row condition is recycled to `n`; an `n`-row matrix/data frame supplies observation-specific conditions.
- Condition columns follow the user-supplied `conditioning_set` order. Without an explicit set, they refer to the tail of the current vine order.
- Discrete copula-scale conditions accept both backend layouts: expanded (`2k`, including duplicate left-limit columns for continuous variables) and compact (`k + k_d`, omitting those duplicates). Expanded continuous left-limit columns are validated against their value columns.
- `rvine()` computes copula values and discrete left limits internally from the fitted margins and restores conditioned original-scale values exactly, including ordered factors.
- Reorientation remains internal and is not exposed as R API. The wrapper calls the backend conditioning-set overload, which evaluates through a non-owning reoriented view and does not modify the model.
- Conditioning-aware selection currently requires a full, non-truncated vine and an MST tree algorithm (`mst_prim` or `mst_kruskal`).

## Tests

Frontend tests cover:

- named and indexed conditioning sets and selection restrictions;
- recycling and observation-specific conditions;
- user-set order versus backend tail order;
- non-mutating conditional evaluation;
- continuous and discrete conditions, compact/expanded layout parity, internally generated left limits, and ordered factors;
- pseudorandom and quasi-random reproducibility under `set.seed()`;
- different R seeds producing different free coordinates;
- exact R RNG advancement: one call consumes the 20 draws used by `get_seeds()` and the backend never touches R RNG state;
- identical seeded output with one versus multiple cores;
- conditional simulation through both `rvinecop()` and `rvine()`;
- validation failures for malformed conditioning sets, shapes, ranges, layouts, and left limits.

The complete local `testthat` suite passes against the backend-sync branch.