### PR TITLE
Support vectorized parameters in rbicop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,9 +11,9 @@ The main changes on the R end are:
   option to `dvinecop()` for returning intermediate quantities from density
   evaluation,
 
-* added support for vectorized `parameters` in `dbicop()`, `pbicop()`, and
-  `hbicop()` when parameters are passed directly (vectorized parameters are not
-  supported for `bicop_dist()` objects or for `rbicop()`),
+* added support for vectorized `parameters` in `dbicop()`, `pbicop()`,
+  `hbicop()`, and `rbicop()` when parameters are passed directly (vectorized
+  parameters are not supported for `bicop_dist()` objects),
 
 * aligned the R frontend with the updated vinecopulib 0.8.0 API and tests,
   including the new per-row bicop parameter interface.

--- a/R/bicop_methods.R
+++ b/R/bicop_methods.R
@@ -55,6 +55,8 @@
 #'
 #' The numerical arguments other than `n` are recycled to the length of the
 #' result.
+#' For vectorized simulation, `parameters` must have one row per generated
+#' observation and one column per family parameter.
 #'
 #' @seealso [bicop_dist()], [bicop()]
 #
@@ -109,20 +111,9 @@ rbicop <- function(n, family, rotation, parameters, qrng = FALSE) {
   if (inherits(family, "bicop_dist") & !missing(rotation)) {
     qrng <- rotation
   }
-  assert_that(is.flag(qrng))
+  assert_that(is.count(n), is.flag(qrng))
 
   bicop <- args2bicop(family, rotation, parameters)
-  pars <- as.matrix(bicop$parameters)
-  if (
-    (bicop$family %in% family_set_parametric) &&
-      (nrow(pars) > 1) &&
-      ((ncol(pars) > 1) || (bicop$family %in% family_set_onepar))
-  ) {
-    stop(
-      "rbicop: vectorized 'parameters' are not simulation-compatible.",
-      call. = FALSE
-    )
-  }
   U <- bicop_sim_cpp(bicop, n, qrng, get_seeds())
   if (!is.null(bicop$names)) {
     colnames(U) <- bicop$names

--- a/man/bicop_methods.Rd
+++ b/man/bicop_methods.Rd
@@ -64,6 +64,8 @@ the number of rows in \code{u} for the other functions.
 
 The numerical arguments other than \code{n} are recycled to the length of the
 result.
+For vectorized simulation, \code{parameters} must have one row per generated
+observation and one column per family parameter.
 }
 \description{
 Density, distribution function, random generation and h-functions (with their

--- a/src/vinecopulib-interface.cpp
+++ b/src/vinecopulib-interface.cpp
@@ -163,9 +163,12 @@ Eigen::MatrixXd bicop_sim_cpp(const Rcpp::List& bicop_r,
   Bicop bicop_cpp = bicop_wrap(bicop_r);
   Eigen::MatrixXd parameters = get_bicop_parameters(bicop_r);
   if (has_vectorized_bicop_parameters(bicop_cpp, parameters)) {
-    auto u = tools_stats::simulate_uniform(n, 2, qrng, seeds);
-    u.col(1) = bicop_cpp.as_continuous().hinv1(u, parameters);
-    return u;
+    if (parameters.rows() != static_cast<Eigen::Index>(n)) {
+      throw std::runtime_error(
+        "vectorized parameters must have one row per row of u "
+        "(one per simulated observation)");
+    }
+    return bicop_cpp.simulate(parameters, qrng, seeds);
   }
   return bicop_cpp.simulate(n, qrng, seeds);
 }

--- a/src/vinecopulib-interface.cpp
+++ b/src/vinecopulib-interface.cpp
@@ -161,6 +161,12 @@ Eigen::MatrixXd bicop_sim_cpp(const Rcpp::List& bicop_r,
                               std::vector<int> seeds)
 {
   Bicop bicop_cpp = bicop_wrap(bicop_r);
+  Eigen::MatrixXd parameters = get_bicop_parameters(bicop_r);
+  if (has_vectorized_bicop_parameters(bicop_cpp, parameters)) {
+    auto u = tools_stats::simulate_uniform(n, 2, qrng, seeds);
+    u.col(1) = bicop_cpp.as_continuous().hinv1(u, parameters);
+    return u;
+  }
   return bicop_cpp.simulate(n, qrng, seeds);
 }
 

--- a/tests/testthat/test_bicop_dist.R
+++ b/tests/testthat/test_bicop_dist.R
@@ -335,6 +335,35 @@ test_that("rbicop supports vectorized parameters", {
 
   set.seed(123)
   expect_equal(rbicop(seq_len(n), "gaussian", 0, pars), expected)
+
+  expect_error(
+    rbicop(n - 1L, "gaussian", 0, pars),
+    "one row per row of u"
+  )
+})
+
+test_that("vectorized rbicop is synchronized with the R seed", {
+  n <- 25
+  pars <- matrix(seq(-0.8, 0.8, length.out = n), ncol = 1)
+
+  for (use_qrng in c(FALSE, TRUE)) {
+    set.seed(314)
+    u1 <- rbicop(n, "gaussian", 0, pars, qrng = use_qrng)
+    state_after <- .Random.seed
+
+    set.seed(314)
+    u2 <- rbicop(n, "gaussian", 0, pars, qrng = use_qrng)
+    expect_identical(u2, u1)
+    expect_identical(.Random.seed, state_after)
+
+    set.seed(314)
+    runif(20)
+    expect_identical(.Random.seed, state_after)
+
+    set.seed(315)
+    u3 <- rbicop(n, "gaussian", 0, pars, qrng = use_qrng)
+    expect_false(identical(u3, u1))
+  }
 })
 
 test_that("rbicop vectorization handles rotations and multiple parameters", {

--- a/tests/testthat/test_bicop_dist.R
+++ b/tests/testthat/test_bicop_dist.R
@@ -302,7 +302,6 @@ test_that("vectorized parameter sanity checks are enforced", {
   set.seed(9)
   u <- matrix(runif(20), ncol = 2)
   pars_bad_n <- matrix(seq(-0.5, 0.5, length.out = nrow(u) - 1), ncol = 1)
-  pars_sim <- matrix(c(-0.3, 0.1), ncol = 1)
 
   expect_error(
     dbicop(u, "gaussian", 0, pars_bad_n),
@@ -312,8 +311,66 @@ test_that("vectorized parameter sanity checks are enforced", {
     hbicop(u, 1, "gaussian", 0, pars_bad_n),
     "parameters\\.rows\\(\\) must equal u\\.rows\\(\\)"
   )
+})
+
+test_that("rbicop supports vectorized parameters", {
+  n <- 40
+  pars <- matrix(seq(-0.8, 0.8, length.out = n), ncol = 1)
+
+  set.seed(123)
+  uniforms <- rbicop(n, "indep")
+  expected <- uniforms
+  expected[, 2] <- hbicop(
+    uniforms,
+    1,
+    "gaussian",
+    0,
+    pars,
+    inverse = TRUE
+  )
+
+  set.seed(123)
+  simulated <- rbicop(n, "gaussian", 0, pars)
+  expect_equal(simulated, expected)
+
+  set.seed(123)
+  expect_equal(rbicop(seq_len(n), "gaussian", 0, pars), expected)
+})
+
+test_that("rbicop vectorization handles rotations and multiple parameters", {
+  n <- 30
+  pars <- cbind(
+    seq(1.1, 3.5, length.out = n),
+    seq(1.05, 1.8, length.out = n)
+  )
+
+  set.seed(456)
+  uniforms <- rbicop(n, "indep", qrng = TRUE)
+  expected <- uniforms
+  expected[, 2] <- hbicop(
+    uniforms,
+    1,
+    "bb1",
+    270,
+    pars,
+    inverse = TRUE
+  )
+
+  set.seed(456)
+  expect_equal(rbicop(n, "bb1", 270, pars, qrng = TRUE), expected)
+})
+
+test_that("rbicop validates vectorized simulation inputs", {
+  pars <- matrix(c(-0.3, 0.1), ncol = 1)
+
+  expect_error(rbicop(1.5, "gaussian", 0, 0.2), "not a count")
+  expect_error(rbicop(3, "gaussian", 0, pars), "one row per row of u")
   expect_error(
-    rbicop(10, "gaussian", 0, pars_sim),
-    "not simulation"
+    rbicop(2, "gaussian", 0, matrix(c(0.1, NA_real_), ncol = 1)),
+    "must not contain NaN or Inf"
+  )
+  expect_error(
+    rbicop(2, "gaussian", 0, matrix(c(0.1, -1.1), ncol = 1)),
+    "out of bounds"
   )
 })


### PR DESCRIPTION
## Summary

Adds observation-specific parameter support to `rbicop()`, completing the vectorized bivariate evaluation API. This PR is stacked on #326 and delegates directly to vinecopulib 1.0's per-row-parameter `Bicop::simulate()` overload.

Row `i` is simulated using parameter row `i`, without an R-level loop. Fixed-parameter simulation continues through the existing backend overload.

## API decisions

- vectorized parameters are supported when parameters are passed directly to `rbicop()`
- `bicop_dist()` continues to represent one fixed distribution and still rejects vectorized parameters
- parameter rows are not recycled: the parameter matrix must contain exactly one row per generated observation
- the R wrapper checks the row count explicitly because the backend overload derives sample size from the parameter matrix and does not receive `n` separately
- one-parameter families accept a vector or one-column matrix; multi-parameter families require an `n x p` matrix
- existing scalar-parameter behavior is unchanged
- existing `length(n) > 1` behavior is retained: `length(n)` determines the number of observations
- invalid scalar `n` values are rejected before conversion to the C++ size type

## Tests

The tests compare vectorized simulation exactly with an independently reconstructed inverse Rosenblatt transform using the same random stream. Coverage includes:

- one-parameter Gaussian and rotated two-parameter BB1 simulation
- ordinary and quasi-random generation
- exact reproducibility under `set.seed()` for both RNG modes
- different R seeds producing different samples
- exact R RNG advancement by the 20 draws used by `get_seeds()`
- `length(n)` semantics
- parameter-row mismatches, non-finite and out-of-bounds parameters, and invalid `n`

Results:

- focused bivariate-model tests on the stack: 110 passed
- full release-stack suite: 817 passed, 0 failures, warnings, or skips
- full release-stack `R CMD check`: **Status: OK**
