### PR TITLE
Support custom vine tree criteria

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ https://github.com/vinecopulib/vinecopulib/blob/main/NEWS.md.
 
 The main changes on the R end are:
 
+* `vinecop()` and `vine()` now accept a custom function as `tree_crit`,
+
 * added `scores()` and `hessian()` for vine copula models, and a `keep_all`
   option to `dvinecop()` for returning intermediate quantities from density
   evaluation,

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -113,8 +113,8 @@ vinecop_hessian_cpp <- function(u, vinecop_r, step_wise, cores) {
     .Call(`_rvinecopulib_vinecop_hessian_cpp`, u, vinecop_r, step_wise, cores)
 }
 
-vinecop_select_cpp <- function(data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds, conditioning_set) {
-    .Call(`_rvinecopulib_vinecop_select_cpp`, data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds, conditioning_set)
+vinecop_select_cpp <- function(data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds, conditioning_set, tree_criterion_function) {
+    .Call(`_rvinecopulib_vinecop_select_cpp`, data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds, conditioning_set, tree_criterion_function)
 }
 
 vinecop_fit_cpp <- function(data, vinecop_r, par_method, nonpar_method, mult, weights, show_trace, num_threads, tree_algorithm, seeds) {

--- a/R/vinecop.R
+++ b/R/vinecop.R
@@ -29,7 +29,8 @@
 #'   supplied. Rows containing missing values or zero weights are removed
 #'   before the function is called. The function must return one finite numeric
 #'   value; its absolute value is used as the edge strength. Custom functions
-#'   require `cores = 1`.
+#'   always run serially on the calling thread; pair-copula fitting may still use
+#'   `cores` threads.
 #' @param threshold for thresholded vine copulas; `NA` indicates that the
 #'   threshold should be selected automatically by [mBICV()].
 #' @param vinecop_object a `vinecop` object to be updated; if provided, only the
@@ -253,9 +254,6 @@ vinecop <- function(
   tree_crit_control <- tree_crit
   tree_crit_function <- NULL
   if (is.function(tree_crit)) {
-    if (cores != 1) {
-      stop("custom 'tree_crit' functions require 'cores = 1'.", call. = FALSE)
-    }
     if (!is.null(vinecop_object)) {
       stop(
         "custom 'tree_crit' functions cannot be used when refitting a model.",

--- a/R/vinecop.R
+++ b/R/vinecop.R
@@ -21,7 +21,10 @@
 #' @param tree_crit the criterion for tree selection, one of `"tau"`, `"rho"`,
 #'   `"hoeffd"`, `"mcor"`, or `"joe"` for Kendall's \eqn{\tau}, Spearman's
 #'   \eqn{\rho}, Hoeffding's \eqn{D}, maximum correlation, or logarithm of
-#'   the partial correlation, respectively.
+#'   the partial correlation, respectively. Alternatively, a function with
+#'   arguments `data` (a two-column matrix) and `weights` (normalized to have
+#'   mean one, or `numeric(0)` when no weights were supplied) that returns one
+#'   numeric dependence value. Custom functions require `cores = 1`.
 #' @param threshold for thresholded vine copulas; `NA` indicates that the
 #'   threshold should be selected automatically by [mBICV()].
 #' @param vinecop_object a `vinecop` object to be updated; if provided, only the
@@ -201,7 +204,7 @@ vinecop <- function(
     is.flag(presel),
     is.flag(allow_rotations),
     is.scalar(trunc_lvl),
-    is.string(tree_crit),
+    is.string(tree_crit) || is.function(tree_crit),
     is.scalar(threshold),
     is.flag(keep_data),
     is.number(cores),
@@ -240,6 +243,24 @@ vinecop <- function(
         call. = FALSE
       )
     }
+  }
+
+  tree_crit_control <- tree_crit
+  tree_crit_function <- NULL
+  if (is.function(tree_crit)) {
+    if (cores != 1) {
+      stop("custom 'tree_crit' functions require 'cores = 1'.", call. = FALSE)
+    }
+    if (!is.null(vinecop_object)) {
+      stop(
+        "custom 'tree_crit' functions cannot be used when refitting a model.",
+        call. = FALSE
+      )
+    }
+    tree_crit_function <- tree_crit
+    tree_crit <- "custom"
+  } else if (identical(tree_crit, "custom")) {
+    stop("'tree_crit = \"custom\"' requires a function.", call. = FALSE)
   }
 
   seeds <- get_seeds()
@@ -294,6 +315,7 @@ vinecop <- function(
         .Machine$integer.max
       ),
       tree_criterion = tree_crit,
+      tree_criterion_function = tree_crit_function,
       threshold = threshold,
       select_truncation_level = is.na(trunc_lvl),
       select_threshold = is.na(threshold),
@@ -329,7 +351,7 @@ vinecop <- function(
     presel = presel,
     allow_rotations = allow_rotations,
     trunc_lvl = trunc_lvl,
-    tree_crit = tree_crit,
+    tree_crit = tree_crit_control,
     threshold = threshold,
     tree_algorithm = tree_algorithm,
     conditioning_set = conditioning_set

--- a/R/vinecop.R
+++ b/R/vinecop.R
@@ -22,9 +22,14 @@
 #'   `"hoeffd"`, `"mcor"`, or `"joe"` for Kendall's \eqn{\tau}, Spearman's
 #'   \eqn{\rho}, Hoeffding's \eqn{D}, maximum correlation, or logarithm of
 #'   the partial correlation, respectively. Alternatively, a function with
-#'   arguments `data` (a two-column matrix) and `weights` (normalized to have
-#'   mean one, or `numeric(0)` when no weights were supplied) that returns one
-#'   numeric dependence value. Custom functions require `cores = 1`.
+#'   arguments `data` and `weights` may be supplied. `data` is a two-column
+#'   matrix of pair-copula pseudo-observations. `weights` contains the
+#'   corresponding observation weights, standardized by the backend to sum to
+#'   the original number of observations, or `numeric(0)` when no weights were
+#'   supplied. Rows containing missing values or zero weights are removed
+#'   before the function is called. The function must return one finite numeric
+#'   value; its absolute value is used as the edge strength. Custom functions
+#'   require `cores = 1`.
 #' @param threshold for thresholded vine copulas; `NA` indicates that the
 #'   threshold should be selected automatically by [mBICV()].
 #' @param vinecop_object a `vinecop` object to be updated; if provided, only the

--- a/man/vinecop.Rd
+++ b/man/vinecop.Rd
@@ -83,9 +83,14 @@ automatically by \code{\link[=mBICV]{mBICV()}}.}
 \code{"hoeffd"}, \code{"mcor"}, or \code{"joe"} for Kendall's \eqn{\tau}, Spearman's
 \eqn{\rho}, Hoeffding's \eqn{D}, maximum correlation, or logarithm of
 the partial correlation, respectively. Alternatively, a function with
-arguments \code{data} (a two-column matrix) and \code{weights} (normalized to have
-mean one, or \code{numeric(0)} when no weights were supplied) that returns one
-numeric dependence value. Custom functions require \code{cores = 1}.}
+arguments \code{data} and \code{weights} may be supplied. \code{data} is a two-column
+matrix of pair-copula pseudo-observations. \code{weights} contains the
+corresponding observation weights, standardized by the backend to sum to
+the original number of observations, or \code{numeric(0)} when no weights were
+supplied. Rows containing missing values or zero weights are removed
+before the function is called. The function must return one finite numeric
+value; its absolute value is used as the edge strength. Custom functions
+require \code{cores = 1}.}
 
 \item{threshold}{for thresholded vine copulas; \code{NA} indicates that the
 threshold should be selected automatically by \code{\link[=mBICV]{mBICV()}}.}

--- a/man/vinecop.Rd
+++ b/man/vinecop.Rd
@@ -82,7 +82,10 @@ automatically by \code{\link[=mBICV]{mBICV()}}.}
 \item{tree_crit}{the criterion for tree selection, one of \code{"tau"}, \code{"rho"},
 \code{"hoeffd"}, \code{"mcor"}, or \code{"joe"} for Kendall's \eqn{\tau}, Spearman's
 \eqn{\rho}, Hoeffding's \eqn{D}, maximum correlation, or logarithm of
-the partial correlation, respectively.}
+the partial correlation, respectively. Alternatively, a function with
+arguments \code{data} (a two-column matrix) and \code{weights} (normalized to have
+mean one, or \code{numeric(0)} when no weights were supplied) that returns one
+numeric dependence value. Custom functions require \code{cores = 1}.}
 
 \item{threshold}{for thresholded vine copulas; \code{NA} indicates that the
 threshold should be selected automatically by \code{\link[=mBICV]{mBICV()}}.}

--- a/man/vinecop.Rd
+++ b/man/vinecop.Rd
@@ -90,7 +90,8 @@ the original number of observations, or \code{numeric(0)} when no weights were
 supplied. Rows containing missing values or zero weights are removed
 before the function is called. The function must return one finite numeric
 value; its absolute value is used as the edge strength. Custom functions
-require \code{cores = 1}.}
+always run serially on the calling thread; pair-copula fitting may still use
+\code{cores} threads.}
 
 \item{threshold}{for thresholded vine copulas; \code{NA} indicates that the
 threshold should be selected automatically by \code{\link[=mBICV]{mBICV()}}.}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -375,8 +375,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // vinecop_select_cpp
-Rcpp::List vinecop_select_cpp(const Eigen::MatrixXd& data, Rcpp::List& structure, std::vector<std::string> family_set, std::string par_method, std::string nonpar_method, double mult, int truncation_level, std::string tree_criterion, double threshold, std::string selection_criterion, const Eigen::VectorXd& weights, double psi0, bool select_truncation_level, bool select_threshold, bool preselect_families, bool select_families, bool allow_rotations, bool show_trace, size_t num_threads, std::vector<std::string> var_types, std::string tree_algorithm, std::vector<int> seeds, std::vector<size_t> conditioning_set);
-RcppExport SEXP _rvinecopulib_vinecop_select_cpp(SEXP dataSEXP, SEXP structureSEXP, SEXP family_setSEXP, SEXP par_methodSEXP, SEXP nonpar_methodSEXP, SEXP multSEXP, SEXP truncation_levelSEXP, SEXP tree_criterionSEXP, SEXP thresholdSEXP, SEXP selection_criterionSEXP, SEXP weightsSEXP, SEXP psi0SEXP, SEXP select_truncation_levelSEXP, SEXP select_thresholdSEXP, SEXP preselect_familiesSEXP, SEXP select_familiesSEXP, SEXP allow_rotationsSEXP, SEXP show_traceSEXP, SEXP num_threadsSEXP, SEXP var_typesSEXP, SEXP tree_algorithmSEXP, SEXP seedsSEXP, SEXP conditioning_setSEXP) {
+Rcpp::List vinecop_select_cpp(const Eigen::MatrixXd& data, Rcpp::List& structure, std::vector<std::string> family_set, std::string par_method, std::string nonpar_method, double mult, int truncation_level, std::string tree_criterion, double threshold, std::string selection_criterion, const Eigen::VectorXd& weights, double psi0, bool select_truncation_level, bool select_threshold, bool preselect_families, bool select_families, bool allow_rotations, bool show_trace, size_t num_threads, std::vector<std::string> var_types, std::string tree_algorithm, std::vector<int> seeds, std::vector<size_t> conditioning_set, SEXP tree_criterion_function);
+RcppExport SEXP _rvinecopulib_vinecop_select_cpp(SEXP dataSEXP, SEXP structureSEXP, SEXP family_setSEXP, SEXP par_methodSEXP, SEXP nonpar_methodSEXP, SEXP multSEXP, SEXP truncation_levelSEXP, SEXP tree_criterionSEXP, SEXP thresholdSEXP, SEXP selection_criterionSEXP, SEXP weightsSEXP, SEXP psi0SEXP, SEXP select_truncation_levelSEXP, SEXP select_thresholdSEXP, SEXP preselect_familiesSEXP, SEXP select_familiesSEXP, SEXP allow_rotationsSEXP, SEXP show_traceSEXP, SEXP num_threadsSEXP, SEXP var_typesSEXP, SEXP tree_algorithmSEXP, SEXP seedsSEXP, SEXP conditioning_setSEXP, SEXP tree_criterion_functionSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -403,7 +403,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::string >::type tree_algorithm(tree_algorithmSEXP);
     Rcpp::traits::input_parameter< std::vector<int> >::type seeds(seedsSEXP);
     Rcpp::traits::input_parameter< std::vector<size_t> >::type conditioning_set(conditioning_setSEXP);
-    rcpp_result_gen = Rcpp::wrap(vinecop_select_cpp(data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds, conditioning_set));
+    Rcpp::traits::input_parameter< SEXP >::type tree_criterion_function(tree_criterion_functionSEXP);
+    rcpp_result_gen = Rcpp::wrap(vinecop_select_cpp(data, structure, family_set, par_method, nonpar_method, mult, truncation_level, tree_criterion, threshold, selection_criterion, weights, psi0, select_truncation_level, select_threshold, preselect_families, select_families, allow_rotations, show_trace, num_threads, var_types, tree_algorithm, seeds, conditioning_set, tree_criterion_function));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -476,7 +477,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rvinecopulib_vinecop_cdf_cpp", (DL_FUNC) &_rvinecopulib_vinecop_cdf_cpp, 5},
     {"_rvinecopulib_vinecop_scores_cpp", (DL_FUNC) &_rvinecopulib_vinecop_scores_cpp, 4},
     {"_rvinecopulib_vinecop_hessian_cpp", (DL_FUNC) &_rvinecopulib_vinecop_hessian_cpp, 4},
-    {"_rvinecopulib_vinecop_select_cpp", (DL_FUNC) &_rvinecopulib_vinecop_select_cpp, 23},
+    {"_rvinecopulib_vinecop_select_cpp", (DL_FUNC) &_rvinecopulib_vinecop_select_cpp, 24},
     {"_rvinecopulib_vinecop_fit_cpp", (DL_FUNC) &_rvinecopulib_vinecop_fit_cpp, 10},
     {"_rvinecopulib_fit_margins_cpp", (DL_FUNC) &_rvinecopulib_fit_margins_cpp, 9},
     {NULL, NULL, 0}

--- a/src/vinecopulib-interface.cpp
+++ b/src/vinecopulib-interface.cpp
@@ -2,6 +2,7 @@
 #include "kde1d-wrappers.hpp"
 
 #include <algorithm>
+#include <cmath>
 
 using namespace vinecopulib;
 
@@ -388,7 +389,8 @@ Rcpp::List vinecop_select_cpp(const Eigen::MatrixXd &data,
                               std::vector<std::string> var_types,
                               std::string tree_algorithm,
                               std::vector<int> seeds,
-                              std::vector<size_t> conditioning_set)
+                              std::vector<size_t> conditioning_set,
+                              SEXP tree_criterion_function)
 {
   std::vector<BicopFamily> fam_set(family_set.size());
   for (unsigned int fam = 0; fam < fam_set.size(); ++fam) {
@@ -408,6 +410,28 @@ Rcpp::List vinecop_select_cpp(const Eigen::MatrixXd &data,
   fit_controls.set_num_threads(num_threads);
   fit_controls.set_trunc_lvl(truncation_level);
   fit_controls.set_tree_criterion(tree_criterion);
+  if (!Rf_isNull(tree_criterion_function)) {
+    Rcpp::Function criterion(tree_criterion_function);
+    fit_controls.set_tree_criterion_function(
+      [criterion](const Eigen::MatrixXd& criterion_data,
+                  const Eigen::VectorXd& criterion_weights) {
+        Rcpp::RObject result = criterion(
+          Rcpp::wrap(criterion_data),
+          Rcpp::wrap(criterion_weights)
+        );
+        if (!Rf_isNumeric(result) || Rf_xlength(result) != 1) {
+          Rcpp::stop("custom 'tree_crit' must return one numeric value.");
+        }
+        const double value = Rcpp::as<double>(result);
+        if (!std::isfinite(value)) {
+          Rcpp::stop(
+            "custom 'tree_crit' must return a finite numeric value."
+          );
+        }
+        return value;
+      }
+    );
+  }
   fit_controls.set_threshold(threshold);
   fit_controls.set_select_threshold(select_threshold);
   fit_controls.set_select_trunc_lvl(select_truncation_level);

--- a/tests/testthat/test_vine.R
+++ b/tests/testthat/test_vine.R
@@ -111,6 +111,28 @@ test_that("weights work", {
   expect_false(identical(fit$margins[[1]], fit_weights$margins[[1]]))
 })
 
+test_that("custom tree criteria are available through vine", {
+  n_calls <- 0L
+  custom_criterion <- function(data, weights) {
+    n_calls <<- n_calls + 1L
+    abs(cor(data[, 1], data[, 2]))
+  }
+  fit_custom <- vine(
+    as.data.frame(u[, 1:3]),
+    copula_controls = list(
+      family_set = "indep",
+      tree_crit = custom_criterion
+    )
+  )
+
+  expect_s3_class(fit_custom, "vine")
+  expect_gt(n_calls, 0L)
+  expect_identical(
+    fit_custom$copula_controls$tree_crit,
+    custom_criterion
+  )
+})
+
 test_that("d = 1 works", {
   vc <- vine(runif(20))
   expect_eql(dim(summary(vc)$margins)[1], 1)

--- a/tests/testthat/test_vinecop.R
+++ b/tests/testthat/test_vinecop.R
@@ -305,10 +305,6 @@ test_that("custom tree criterion safeguards are enforced", {
   valid_criterion <- function(data, weights) 0.5
 
   expect_error(
-    vinecop(u_custom, tree_crit = valid_criterion, cores = 2),
-    "require 'cores = 1'"
-  )
-  expect_error(
     vinecop(u_custom, tree_crit = "custom"),
     "requires a function"
   )
@@ -340,6 +336,38 @@ test_that("custom tree criterion safeguards are enforced", {
   expect_error(
     vinecop(u_custom, tree_crit = function(data, weights) stop("boom")),
     "boom"
+  )
+})
+
+test_that("custom tree criteria support multicore pair-copula fitting", {
+  set.seed(17)
+  u_custom <- matrix(runif(400), ncol = 4)
+  n_calls <- 0L
+  criterion <- function(data, weights) {
+    n_calls <<- n_calls + 1L
+    abs(cor(data[, 1], data[, 2], method = "kendall"))
+  }
+
+  fit_parallel <- vinecop(
+    u_custom,
+    family_set = "indep",
+    tree_crit = criterion,
+    cores = 2
+  )
+  parallel_calls <- n_calls
+  expect_gt(parallel_calls, 0L)
+
+  n_calls <- 0L
+  fit_serial <- vinecop(
+    u_custom,
+    family_set = "indep",
+    tree_crit = criterion,
+    cores = 1
+  )
+  expect_identical(n_calls, parallel_calls)
+  expect_equal(
+    as_rvine_matrix(fit_parallel$structure),
+    as_rvine_matrix(fit_serial$structure)
   )
 })
 

--- a/tests/testthat/test_vinecop.R
+++ b/tests/testthat/test_vinecop.R
@@ -239,7 +239,7 @@ test_that("custom tree criteria are passed through", {
   custom_tau <- function(data, weights) {
     n_calls <<- n_calls + 1L
     seen_weights <<- weights
-    cor(data[, 1], data[, 2], method = "kendall")
+    -abs(cor(data[, 1], data[, 2], method = "kendall"))
   }
 
   fit_custom <- vinecop(
@@ -272,6 +272,32 @@ test_that("custom tree criteria are passed through", {
     }
   )
   expect_equal(seen_weights, obs_weights / mean(obs_weights))
+})
+
+test_that("custom tree criteria receive filtered data and weights", {
+  set.seed(16)
+  u_custom <- matrix(runif(60), ncol = 2)
+  u_custom[1, 1] <- NA_real_
+  obs_weights <- seq_len(nrow(u_custom))
+  obs_weights[2] <- 0
+  seen_data <- NULL
+  seen_weights <- NULL
+
+  vinecop(
+    u_custom,
+    family_set = "indep",
+    weights = obs_weights,
+    tree_crit = function(data, weights) {
+      seen_data <<- data
+      seen_weights <<- weights
+      0.5
+    }
+  )
+
+  standardized_weights <- obs_weights / sum(obs_weights) * length(obs_weights)
+  expect_equal(dim(seen_data), c(28L, 2L))
+  expect_false(anyNA(seen_data))
+  expect_setequal(seen_weights, standardized_weights[-c(1, 2)])
 })
 
 test_that("custom tree criterion safeguards are enforced", {

--- a/tests/testthat/test_vinecop.R
+++ b/tests/testthat/test_vinecop.R
@@ -231,6 +231,92 @@ test_that("conditioning-aware selection is exposed through the R controls", {
   )
 })
 
+test_that("custom tree criteria are passed through", {
+  set.seed(15)
+  u_custom <- matrix(runif(400), ncol = 4)
+  n_calls <- 0L
+  seen_weights <- NULL
+  custom_tau <- function(data, weights) {
+    n_calls <<- n_calls + 1L
+    seen_weights <<- weights
+    cor(data[, 1], data[, 2], method = "kendall")
+  }
+
+  fit_custom <- vinecop(
+    u_custom,
+    family_set = "indep",
+    tree_crit = custom_tau
+  )
+  fit_tau <- vinecop(
+    u_custom,
+    family_set = "indep",
+    tree_crit = "tau"
+  )
+
+  expect_gt(n_calls, 0L)
+  expect_length(seen_weights, 0L)
+  expect_equal(
+    as_rvine_matrix(fit_custom$structure),
+    as_rvine_matrix(fit_tau$structure)
+  )
+  expect_identical(fit_custom$controls$tree_crit, custom_tau)
+
+  obs_weights <- seq_len(nrow(u_custom))
+  vinecop(
+    u_custom,
+    family_set = "indep",
+    weights = obs_weights,
+    tree_crit = function(data, weights) {
+      seen_weights <<- weights
+      0.5
+    }
+  )
+  expect_equal(seen_weights, obs_weights / mean(obs_weights))
+})
+
+test_that("custom tree criterion safeguards are enforced", {
+  u_custom <- matrix(runif(90), ncol = 3)
+  valid_criterion <- function(data, weights) 0.5
+
+  expect_error(
+    vinecop(u_custom, tree_crit = valid_criterion, cores = 2),
+    "require 'cores = 1'"
+  )
+  expect_error(
+    vinecop(u_custom, tree_crit = "custom"),
+    "requires a function"
+  )
+  fit_custom <- vinecop(u_custom, family_set = "indep")
+  expect_error(
+    vinecop(
+      u_custom,
+      vinecop_object = fit_custom,
+      tree_crit = valid_criterion
+    ),
+    "cannot be used when refitting"
+  )
+  expect_error(
+    vinecop(u_custom, tree_crit = function(data, weights) c(0.1, 0.2)),
+    "return one numeric value"
+  )
+  expect_error(
+    vinecop(u_custom, tree_crit = function(data, weights) "bad"),
+    "return one numeric value"
+  )
+  expect_error(
+    vinecop(u_custom, tree_crit = function(data, weights) NA_real_),
+    "return a finite numeric value"
+  )
+  expect_error(
+    vinecop(u_custom, tree_crit = function(data, weights) Inf),
+    "return a finite numeric value"
+  )
+  expect_error(
+    vinecop(u_custom, tree_crit = function(data, weights) stop("boom")),
+    "boom"
+  )
+})
+
 test_that("d = 1 works", {
   vc <- vinecop(runif(20), structure = rvine_structure(1))
   vc2 <- vinecop(runif(20))


### PR DESCRIPTION
## Summary

- allow `tree_crit` to be an R function in `vinecop()`
- pass custom criteria through `vine()` via `copula_controls`
- bridge the R callback to the backend custom tree-criterion function
- preserve the callback in fitted-model controls
- document callback inputs, filtering, normalization, and edge-strength semantics
- allow multithreaded pair-copula fitting while the backend invokes R callbacks serially on the calling thread

## API decisions

A custom criterion has the form `function(data, weights)`, where:

- `data` is the two-column pseudo-observation matrix for a candidate edge
- `weights` contains the corresponding backend-standardized observation weights, or `numeric(0)` if no weights were supplied
- rows with missing values or zero weights are removed before invocation
- the callback returns one finite numeric value, whose absolute value is used as edge strength

Additional behavior:

- custom callbacks are serialized by the backend and therefore work with `cores > 1`; `cores` may still parallelize pair-copula fitting
- the literal string `custom` is rejected unless an actual function is supplied
- custom criteria are rejected with `vinecop_object` because refitting does not select a structure
- existing character-valued criteria are unchanged

## Tests

Added coverage for:

- equivalence with the built-in Kendall tau criterion
- absolute-value edge-strength semantics
- weighted and unweighted callbacks
- standardized weights and removal of missing/zero-weight rows
- passthrough through `vine()`
- preservation in fitted-model controls
- one- versus two-thread callback counts and selected structures
- rejection during refitting
- missing callbacks, invalid result type or length, and non-finite results
- propagation of callback errors

Results:

- focused `vinecop` tests: 241 passed
- full release-stack testthat suite: 817 passed, 0 failures, warnings, or skips
- full release-stack `R CMD check`: **Status: OK**

This PR is stacked on #329 and ultimately #328, which imports the required backend callback-serialization support.
