### PR TITLE
Support observation-specific parameters in dvinecop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@ The main changes on the R end are:
   `hbicop()`, and `rbicop()` when parameters are passed directly (vectorized
   parameters are not supported for `bicop_dist()` objects),
 
+* added support for observation-specific parameters in `dvinecop()` for
+  continuous parametric vine copula models,
+
 * aligned the R frontend with the updated vinecopulib 0.8.0 API and tests,
   including the new per-row bicop parameter interface.
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -101,12 +101,12 @@ vinecop_sim_conditional_cpp <- function(vinecop_r, u_cond, conditioning_set, qrn
     .Call(`_rvinecopulib_vinecop_sim_conditional_cpp`, vinecop_r, u_cond, conditioning_set, qrng, cores, seeds)
 }
 
-vinecop_pdf_cpp <- function(u, vinecop_r, cores) {
-    .Call(`_rvinecopulib_vinecop_pdf_cpp`, u, vinecop_r, cores)
+vinecop_pdf_cpp <- function(u, vinecop_r, parameters, cores) {
+    .Call(`_rvinecopulib_vinecop_pdf_cpp`, u, vinecop_r, parameters, cores)
 }
 
-vinecop_pdf_full_cpp <- function(u, vinecop_r, cores) {
-    .Call(`_rvinecopulib_vinecop_pdf_full_cpp`, u, vinecop_r, cores)
+vinecop_pdf_full_cpp <- function(u, vinecop_r, parameters, cores) {
+    .Call(`_rvinecopulib_vinecop_pdf_full_cpp`, u, vinecop_r, parameters, cores)
 }
 
 vinecop_cdf_cpp <- function(u, vinecop_r, N, cores, seeds) {

--- a/R/vinecop_methods.R
+++ b/R/vinecop_methods.R
@@ -26,6 +26,13 @@
 #'   block of `u_cond`. When `NULL`, the columns of `u_cond` correspond to the
 #'   last variables of the current vine order. When supplied, the model is
 #'   transiently reoriented and is not modified.
+#' @param parameters optional observation-specific parameters for `dvinecop()`,
+#'   `scores()`, and `hessian()`. For a model with one parameter, this may be a
+#'   vector with one entry per observation. Otherwise, it must be a matrix with
+#'   one row per observation and one column per model parameter. For vine
+#'   copulas, columns follow the `(tree, edge, parameter)` order of `scores()`.
+#'   Parameters are not recycled. Only continuous parametric models are
+#'   supported.
 #' @details See [vinecop()] for the estimation and construction of vine copula
 #' models.
 #'
@@ -114,7 +121,13 @@
 #' )
 #' @rdname vinecop_methods
 #' @export
-dvinecop <- function(u, vinecop, cores = 1, keep_all = FALSE) {
+dvinecop <- function(
+  u,
+  vinecop,
+  cores = 1,
+  keep_all = FALSE,
+  parameters = NULL
+) {
   assert_that(
     inherits(vinecop, "vinecop_dist"),
     is.number(cores),
@@ -122,10 +135,15 @@ dvinecop <- function(u, vinecop, cores = 1, keep_all = FALSE) {
     is.flag(keep_all)
   )
   u <- if_vec_to_matrix(u, dim(vinecop)[1] == 1)
+  if (is.null(parameters)) {
+    parameters <- matrix(numeric(), 0, 0)
+  }
+  assert_that(is.numeric(parameters))
+  parameters <- as.matrix(parameters)
   if (keep_all) {
-    vinecop_pdf_full_cpp(u, vinecop, cores)
+    vinecop_pdf_full_cpp(u, vinecop, parameters, cores)
   } else {
-    vinecop_pdf_cpp(u, vinecop, cores)
+    vinecop_pdf_cpp(u, vinecop, parameters, cores)
   }
 }
 
@@ -133,12 +151,6 @@ dvinecop <- function(u, vinecop, cores = 1, keep_all = FALSE) {
 #' @param step_wise if `FALSE`, the score/Hessian is computed for the full
 #'   likelihood; if `TRUE`, gradients are computed per pair-copula as in
 #'   step-wise estimation.
-#' @param parameters optional observation-specific parameters. For a
-#'   one-parameter bivariate family, this may be a vector with one entry per
-#'   observation. Otherwise, it must be a matrix with one row per observation
-#'   and one column per model parameter. For vine copulas, columns follow the
-#'   `(tree, edge, parameter)` order of `scores()`. Parameters are not recycled.
-#'   Only continuous parametric models are supported.
 #' @export
 scores <- function(u, vinecop, ...) {
   UseMethod("scores", vinecop)
@@ -413,7 +425,12 @@ predict.vinecop <- function(
   newdata <- if_vec_to_matrix(newdata, dim(object)[1] == 1)
   switch(
     what,
-    "pdf" = vinecop_pdf_cpp(newdata, object, cores),
+    "pdf" = vinecop_pdf_cpp(
+      newdata,
+      object,
+      matrix(numeric(), 0, 0),
+      cores
+    ),
     "cdf" = vinecop_cdf_cpp(newdata, object, n_mc, cores, get_seeds())
   )
 }
@@ -432,7 +449,12 @@ fitted.vinecop <- function(object, what = "pdf", n_mc = 10^4, cores = 1, ...) {
   )
   switch(
     what,
-    "pdf" = vinecop_pdf_cpp(object$data, object, cores),
+    "pdf" = vinecop_pdf_cpp(
+      object$data,
+      object,
+      matrix(numeric(), 0, 0),
+      cores
+    ),
     "cdf" = vinecop_cdf_cpp(object$data, object, n_mc, cores, get_seeds())
   )
 }

--- a/man/vinecop_methods.Rd
+++ b/man/vinecop_methods.Rd
@@ -14,7 +14,7 @@
 \alias{hessian.vinecop_dist}
 \title{Vine copula distributions}
 \usage{
-dvinecop(u, vinecop, cores = 1, keep_all = FALSE)
+dvinecop(u, vinecop, cores = 1, keep_all = FALSE, parameters = NULL)
 
 scores(u, vinecop, ...)
 
@@ -50,16 +50,17 @@ quantities computed during density evaluation.}
 
 \item{...}{unused.}
 
+\item{parameters}{optional observation-specific parameters for \code{dvinecop()},
+\code{scores()}, and \code{hessian()}. For a model with one parameter, this may be a
+vector with one entry per observation. Otherwise, it must be a matrix with
+one row per observation and one column per model parameter. For vine
+copulas, columns follow the \verb{(tree, edge, parameter)} order of \code{scores()}.
+Parameters are not recycled. Only continuous parametric models are
+supported.}
+
 \item{step_wise}{if \code{FALSE}, the score/Hessian is computed for the full
 likelihood; if \code{TRUE}, gradients are computed per pair-copula as in
 step-wise estimation.}
-
-\item{parameters}{optional observation-specific parameters. For a
-one-parameter bivariate family, this may be a vector with one entry per
-observation. Otherwise, it must be a matrix with one row per observation
-and one column per model parameter. For vine copulas, columns follow the
-\verb{(tree, edge, parameter)} order of \code{scores()}. Parameters are not recycled.
-Only continuous parametric models are supported.}
 
 \item{n_mc}{number of samples used for quasi Monte Carlo integration.}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -334,28 +334,30 @@ BEGIN_RCPP
 END_RCPP
 }
 // vinecop_pdf_cpp
-Eigen::VectorXd vinecop_pdf_cpp(const Eigen::MatrixXd& u, const Rcpp::List& vinecop_r, size_t cores);
-RcppExport SEXP _rvinecopulib_vinecop_pdf_cpp(SEXP uSEXP, SEXP vinecop_rSEXP, SEXP coresSEXP) {
+Eigen::VectorXd vinecop_pdf_cpp(const Eigen::MatrixXd& u, const Rcpp::List& vinecop_r, const Eigen::MatrixXd& parameters, size_t cores);
+RcppExport SEXP _rvinecopulib_vinecop_pdf_cpp(SEXP uSEXP, SEXP vinecop_rSEXP, SEXP parametersSEXP, SEXP coresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type u(uSEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type vinecop_r(vinecop_rSEXP);
+    Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type parameters(parametersSEXP);
     Rcpp::traits::input_parameter< size_t >::type cores(coresSEXP);
-    rcpp_result_gen = Rcpp::wrap(vinecop_pdf_cpp(u, vinecop_r, cores));
+    rcpp_result_gen = Rcpp::wrap(vinecop_pdf_cpp(u, vinecop_r, parameters, cores));
     return rcpp_result_gen;
 END_RCPP
 }
 // vinecop_pdf_full_cpp
-Rcpp::List vinecop_pdf_full_cpp(const Eigen::MatrixXd& u, const Rcpp::List& vinecop_r, size_t cores);
-RcppExport SEXP _rvinecopulib_vinecop_pdf_full_cpp(SEXP uSEXP, SEXP vinecop_rSEXP, SEXP coresSEXP) {
+Rcpp::List vinecop_pdf_full_cpp(const Eigen::MatrixXd& u, const Rcpp::List& vinecop_r, const Eigen::MatrixXd& parameters, size_t cores);
+RcppExport SEXP _rvinecopulib_vinecop_pdf_full_cpp(SEXP uSEXP, SEXP vinecop_rSEXP, SEXP parametersSEXP, SEXP coresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type u(uSEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type vinecop_r(vinecop_rSEXP);
+    Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type parameters(parametersSEXP);
     Rcpp::traits::input_parameter< size_t >::type cores(coresSEXP);
-    rcpp_result_gen = Rcpp::wrap(vinecop_pdf_full_cpp(u, vinecop_r, cores));
+    rcpp_result_gen = Rcpp::wrap(vinecop_pdf_full_cpp(u, vinecop_r, parameters, cores));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -504,8 +506,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rvinecopulib_vinecop_rosenblatt_cpp", (DL_FUNC) &_rvinecopulib_vinecop_rosenblatt_cpp, 6},
     {"_rvinecopulib_vinecop_sim_cpp", (DL_FUNC) &_rvinecopulib_vinecop_sim_cpp, 5},
     {"_rvinecopulib_vinecop_sim_conditional_cpp", (DL_FUNC) &_rvinecopulib_vinecop_sim_conditional_cpp, 6},
-    {"_rvinecopulib_vinecop_pdf_cpp", (DL_FUNC) &_rvinecopulib_vinecop_pdf_cpp, 3},
-    {"_rvinecopulib_vinecop_pdf_full_cpp", (DL_FUNC) &_rvinecopulib_vinecop_pdf_full_cpp, 3},
+    {"_rvinecopulib_vinecop_pdf_cpp", (DL_FUNC) &_rvinecopulib_vinecop_pdf_cpp, 4},
+    {"_rvinecopulib_vinecop_pdf_full_cpp", (DL_FUNC) &_rvinecopulib_vinecop_pdf_full_cpp, 4},
     {"_rvinecopulib_vinecop_cdf_cpp", (DL_FUNC) &_rvinecopulib_vinecop_cdf_cpp, 5},
     {"_rvinecopulib_vinecop_scores_cpp", (DL_FUNC) &_rvinecopulib_vinecop_scores_cpp, 5},
     {"_rvinecopulib_vinecop_hessian_cpp", (DL_FUNC) &_rvinecopulib_vinecop_hessian_cpp, 5},

--- a/src/vinecopulib-interface.cpp
+++ b/src/vinecopulib-interface.cpp
@@ -329,9 +329,14 @@ Eigen::MatrixXd vinecop_sim_conditional_cpp(
 // [[Rcpp::export()]]
 Eigen::VectorXd vinecop_pdf_cpp(const Eigen::MatrixXd& u,
                                 const Rcpp::List& vinecop_r,
+                                const Eigen::MatrixXd& parameters,
                                 size_t cores)
 {
-  return vinecop_wrap(vinecop_r).pdf(u, cores);
+  Vinecop vinecop_cpp = vinecop_wrap(vinecop_r);
+  if (parameters.size() > 0) {
+    return vinecop_cpp.pdf(u, parameters, cores);
+  }
+  return vinecop_cpp.pdf(u, cores);
 }
 
 inline Rcpp::NumericVector eigen_vector_wrap(const Eigen::VectorXd& x)
@@ -360,9 +365,13 @@ inline Rcpp::List vector_triangular_array_wrap(
 // [[Rcpp::export()]]
 Rcpp::List vinecop_pdf_full_cpp(const Eigen::MatrixXd& u,
                                 const Rcpp::List& vinecop_r,
+                                const Eigen::MatrixXd& parameters,
                                 size_t cores)
 {
-  auto result = vinecop_wrap(vinecop_r).pdf_full(u, cores, true);
+  Vinecop vinecop_cpp = vinecop_wrap(vinecop_r);
+  auto result = parameters.size() > 0
+                  ? vinecop_cpp.pdf_full(u, parameters, cores, true)
+                  : vinecop_cpp.pdf_full(u, cores, true);
   return Rcpp::List::create(
     Rcpp::Named("pdf") = eigen_vector_wrap(result.pdf),
     Rcpp::Named("pdf_edges") = vector_triangular_array_wrap(result.pdf_edges),

--- a/tests/testthat/test_vinecop_dist.R
+++ b/tests/testthat/test_vinecop_dist.R
@@ -74,6 +74,7 @@ test_that("d/p/r- functions work", {
   )
   expect_equal(dvinecop(u, vc, cores = 2), dvinecop(u, vc))
   expect_equal(dvinecop(u, vc, cores = 2, keep_all = TRUE), pdf_full)
+  expect_equal(dvinecop(u, vc, 2, TRUE), pdf_full)
   expect_gte(min(pvinecop(u, vc, 100)), 0)
   expect_lte(max(pvinecop(u, vc, 100)), 1)
 })
@@ -263,6 +264,134 @@ test_that("conditional simulation accepts discrete left limits", {
       conditioning_set = 4
     ),
     "left-limit columns.*must not exceed"
+  )
+})
+
+test_that("dvinecop accepts full-vine parameter matrices", {
+  u_vectorized <- rvinecop(20, vc)
+  parameters <- matrix(
+    rep(unlist(get_all_parameters(vc)), each = nrow(u_vectorized)),
+    nrow = nrow(u_vectorized)
+  )
+
+  expect_equal(
+    dvinecop(u_vectorized, vc, parameters = parameters),
+    dvinecop(u_vectorized, vc)
+  )
+  expect_equal(
+    dvinecop(
+      u_vectorized,
+      vc,
+      keep_all = TRUE,
+      parameters = parameters
+    ),
+    dvinecop(u_vectorized, vc, keep_all = TRUE)
+  )
+})
+
+test_that("dvinecop supports observation-specific parameters", {
+  set.seed(17)
+  n <- 30
+  u_vectorized <- matrix(runif(2 * n, 0.1, 0.9), ncol = 2)
+  cop <- bicop_dist("gaussian", parameters = 0)
+  vc_vectorized <- vinecop_dist(
+    list(list(cop)),
+    dvine_structure(1:2)
+  )
+  parameters <- seq(-0.7, 0.7, length.out = n)
+
+  density <- dvinecop(
+    u_vectorized,
+    vc_vectorized,
+    parameters = parameters
+  )
+  expect_equal(
+    density,
+    dbicop(u_vectorized, "gaussian", parameters = parameters)
+  )
+  expect_equal(
+    dvinecop(u_vectorized, vc_vectorized, cores = 2, parameters = parameters),
+    density
+  )
+
+  full <- dvinecop(
+    u_vectorized,
+    vc_vectorized,
+    keep_all = TRUE,
+    parameters = parameters
+  )
+  expect_equal(full$pdf, density)
+  expect_equal(full$pdf_edges[[1]][[1]], density)
+  expect_pdf_full_triangular_vectors(full, vc_vectorized, n)
+  expect_equal(
+    dvinecop(
+      u_vectorized,
+      vc_vectorized,
+      cores = 2,
+      keep_all = TRUE,
+      parameters = parameters
+    ),
+    full
+  )
+})
+
+test_that("dvinecop parameter safeguards are enforced", {
+  u_vectorized <- matrix(c(0.2, 0.3, 0.7, 0.8), ncol = 2)
+  cop <- bicop_dist("gaussian", parameters = 0.4)
+  vc_vectorized <- vinecop_dist(list(list(cop)), dvine_structure(1:2))
+
+  expect_error(
+    dvinecop(u_vectorized, vc_vectorized, parameters = "bad"),
+    "not a numeric"
+  )
+  expect_error(
+    dvinecop(u_vectorized, vc_vectorized, parameters = matrix(0.2, 1, 1)),
+    "one row per row of u"
+  )
+  expect_error(
+    dvinecop(
+      u_vectorized,
+      vc_vectorized,
+      parameters = matrix(rep(0.2, 4), nrow = 2)
+    ),
+    "get_npars.*columns"
+  )
+  expect_error(
+    dvinecop(
+      u_vectorized,
+      vc_vectorized,
+      parameters = matrix(c(0.2, NA_real_), ncol = 1)
+    ),
+    "must not contain NaN or Inf"
+  )
+  expect_error(
+    dvinecop(
+      u_vectorized,
+      vc_vectorized,
+      parameters = matrix(c(0.2, 1.1), ncol = 1)
+    ),
+    "out of bounds"
+  )
+
+  vc_discrete <- vc_vectorized
+  vc_discrete$var_types[1] <- "d"
+  u_discrete <- cbind(u_vectorized, u_vectorized[, 1])
+  expect_error(
+    dvinecop(u_discrete, vc_discrete, parameters = matrix(c(0.2, 0.3))),
+    "continuous"
+  )
+
+  vc_nonparametric <- vinecop_dist(
+    list(list(bicop_dist("tll"))),
+    dvine_structure(1:2)
+  )
+  expect_error(
+    dvinecop(
+      u_vectorized,
+      vc_nonparametric,
+      parameters = matrix(numeric(60), nrow = 2)
+    ),
+    "parametric pair copulas"
   )
 })
 


### PR DESCRIPTION
## Summary

- add observation-specific parameter support to dvinecop()
- expose both backend density overloads, including the keep_all path
- preserve existing predict.vinecop() and fitted.vinecop() behavior
- document the parameter layout and supported model types

## API decisions

The new argument is appended to preserve positional compatibility:

dvinecop(u, vinecop, cores = 1, keep_all = FALSE, parameters = NULL)

- parameters = NULL uses parameters stored in the vinecop_dist object
- a vector is accepted when the model has one parameter
- otherwise parameters must be an n x p matrix with exactly one row per observation
- columns follow tree, edge, parameter order
- parameter rows are not recycled
- observation-specific parameters are supported only for continuous, fully parametric vine models
- keep_all = TRUE and threaded evaluation remain supported

## Tests

Added coverage for:

- full-vine parameter matrices and stored-parameter equivalence
- genuinely varying per-observation parameters against dbicop()
- one-parameter vector input
- keep_all output and per-edge quantities
- threaded ordinary and keep_all evaluation
- preservation of the existing positional argument order
- existing predict() and fitted() integration paths
- invalid types, row counts, column counts, non-finite values, and out-of-bounds values
- rejection of discrete and nonparametric models

Results:

- focused vinecop model tests: 267 passed
- full testthat suite: 661 passed, 0 failures, warnings, or skips
- R CMD check: 0 errors, 0 warnings; one worktree-only note because the source worktree contains a .git file