### PR TITLE
Expose conditioning sets in Rosenblatt transforms

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -77,12 +77,12 @@ vinecop_check_cpp <- function(vinecop_r) {
     invisible(.Call(`_rvinecopulib_vinecop_check_cpp`, vinecop_r))
 }
 
-vinecop_inverse_rosenblatt_cpp <- function(U, vinecop_r, cores) {
-    .Call(`_rvinecopulib_vinecop_inverse_rosenblatt_cpp`, U, vinecop_r, cores)
+vinecop_inverse_rosenblatt_cpp <- function(U, vinecop_r, conditioning_set, cores) {
+    .Call(`_rvinecopulib_vinecop_inverse_rosenblatt_cpp`, U, vinecop_r, conditioning_set, cores)
 }
 
-vinecop_rosenblatt_cpp <- function(U, vinecop_r, cores, randomize_discrete, seeds) {
-    .Call(`_rvinecopulib_vinecop_rosenblatt_cpp`, U, vinecop_r, cores, randomize_discrete, seeds)
+vinecop_rosenblatt_cpp <- function(U, vinecop_r, conditioning_set, cores, randomize_discrete, seeds) {
+    .Call(`_rvinecopulib_vinecop_rosenblatt_cpp`, U, vinecop_r, conditioning_set, cores, randomize_discrete, seeds)
 }
 
 vinecop_sim_cpp <- function(vinecop_r, n, qrng, cores, seeds) {

--- a/R/rosenblatt.R
+++ b/R/rosenblatt.R
@@ -17,6 +17,10 @@
 #'    of `u`).
 #' @param randomize_discrete Whether to randomize the transform for discrete
 #'   variables; see Details.
+#' @param conditioning_set optional variable indices or names that define the
+#'   conditioning variables. The transform uses an admissible sampling order
+#'   whose tail contains exactly this set. The model is not modified. If
+#'   `NULL`, the current model order is used.
 #'
 #' @details
 #' The Rosenblatt transform (Rosenblatt, 1952) \eqn{U = T(V)} of a random vector
@@ -85,10 +89,24 @@
 #' vc <- fit$copula
 #' rosenblatt(pseudo_obs(x), vc)
 #' @export
-rosenblatt <- function(x, model, cores = 1, randomize_discrete = TRUE) {
+rosenblatt <- function(
+  x,
+  model,
+  cores = 1,
+  randomize_discrete = TRUE,
+  conditioning_set = NULL
+) {
   assert_that(
     inherits(model, c("bicop_dist", "vinecop_dist", "vine_dist")),
-    is.number(cores)
+    is.number(cores),
+    cores > 0,
+    is.flag(randomize_discrete)
+  )
+
+  conditioning_set <- process_conditioning_set(
+    conditioning_set,
+    model$names,
+    if (inherits(model, "bicop_dist")) 2L else dim(model)[1]
   )
 
   if (inherits(model, "bicop_dist")) {
@@ -112,7 +130,14 @@ rosenblatt <- function(x, model, cores = 1, randomize_discrete = TRUE) {
   assert_that(all((x >= 0) & (x <= 1)))
   x <- pmin(pmax(x, 1e-10), 1 - 1e-10)
   x <- if_vec_to_matrix(x, dim(model)[1] == 1)
-  x <- vinecop_rosenblatt_cpp(x, model, cores, randomize_discrete, get_seeds())
+  x <- vinecop_rosenblatt_cpp(
+    x,
+    model,
+    conditioning_set,
+    cores,
+    randomize_discrete,
+    get_seeds()
+  )
   colnames(x) <- model$names
 
   x
@@ -120,11 +145,23 @@ rosenblatt <- function(x, model, cores = 1, randomize_discrete = TRUE) {
 
 #' @rdname rosenblatt
 #' @export
-inverse_rosenblatt <- function(u, model, cores = 1) {
+inverse_rosenblatt <- function(
+  u,
+  model,
+  cores = 1,
+  conditioning_set = NULL
+) {
   assert_that(
     all((u > 0) & (u < 1)),
     inherits(model, c("bicop_dist", "vinecop_dist", "vine_dist")),
-    is.number(cores)
+    is.number(cores),
+    cores > 0
+  )
+
+  conditioning_set <- process_conditioning_set(
+    conditioning_set,
+    model$names,
+    if (inherits(model, "bicop_dist")) 2L else dim(model)[1]
   )
 
   to_col <- if (inherits(model, "bicop_dist")) FALSE else (dim(model)[1] == 1)
@@ -139,9 +176,14 @@ inverse_rosenblatt <- function(u, model, cores = 1) {
   }
 
   if (inherits(model, "vinecop_dist")) {
-    u <- vinecop_inverse_rosenblatt_cpp(u, model, cores)
+    u <- vinecop_inverse_rosenblatt_cpp(u, model, conditioning_set, cores)
   } else {
-    u <- vinecop_inverse_rosenblatt_cpp(u, model$copula, cores)
+    u <- vinecop_inverse_rosenblatt_cpp(
+      u,
+      model$copula,
+      conditioning_set,
+      cores
+    )
     u <- dpq_marg(u, model, "q")
   }
   colnames(u) <- model$names

--- a/man/rosenblatt.Rd
+++ b/man/rosenblatt.Rd
@@ -5,9 +5,15 @@
 \alias{inverse_rosenblatt}
 \title{(Inverse) Rosenblatt transform}
 \usage{
-rosenblatt(x, model, cores = 1, randomize_discrete = TRUE)
+rosenblatt(
+  x,
+  model,
+  cores = 1,
+  randomize_discrete = TRUE,
+  conditioning_set = NULL
+)
 
-inverse_rosenblatt(u, model, cores = 1)
+inverse_rosenblatt(u, model, cores = 1, conditioning_set = NULL)
 }
 \arguments{
 \item{x}{matrix of evaluation points; must be in \eqn{(0, 1)^d} for copula
@@ -21,6 +27,11 @@ of \code{u}).}
 
 \item{randomize_discrete}{Whether to randomize the transform for discrete
 variables; see Details.}
+
+\item{conditioning_set}{optional variable indices or names that define the
+conditioning variables. The transform uses an admissible sampling order
+whose tail contains exactly this set. The model is not modified. If
+\code{NULL}, the current model order is used.}
 
 \item{u}{matrix of evaluation points; must be in \eqn{(0, 1)^d}.}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -245,30 +245,32 @@ BEGIN_RCPP
 END_RCPP
 }
 // vinecop_inverse_rosenblatt_cpp
-Eigen::MatrixXd vinecop_inverse_rosenblatt_cpp(const Eigen::MatrixXd& U, const Rcpp::List& vinecop_r, size_t cores);
-RcppExport SEXP _rvinecopulib_vinecop_inverse_rosenblatt_cpp(SEXP USEXP, SEXP vinecop_rSEXP, SEXP coresSEXP) {
+Eigen::MatrixXd vinecop_inverse_rosenblatt_cpp(const Eigen::MatrixXd& U, const Rcpp::List& vinecop_r, const std::vector<size_t>& conditioning_set, size_t cores);
+RcppExport SEXP _rvinecopulib_vinecop_inverse_rosenblatt_cpp(SEXP USEXP, SEXP vinecop_rSEXP, SEXP conditioning_setSEXP, SEXP coresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type U(USEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type vinecop_r(vinecop_rSEXP);
+    Rcpp::traits::input_parameter< const std::vector<size_t>& >::type conditioning_set(conditioning_setSEXP);
     Rcpp::traits::input_parameter< size_t >::type cores(coresSEXP);
-    rcpp_result_gen = Rcpp::wrap(vinecop_inverse_rosenblatt_cpp(U, vinecop_r, cores));
+    rcpp_result_gen = Rcpp::wrap(vinecop_inverse_rosenblatt_cpp(U, vinecop_r, conditioning_set, cores));
     return rcpp_result_gen;
 END_RCPP
 }
 // vinecop_rosenblatt_cpp
-Eigen::MatrixXd vinecop_rosenblatt_cpp(const Eigen::MatrixXd& U, const Rcpp::List& vinecop_r, size_t cores, bool randomize_discrete, std::vector<int> seeds);
-RcppExport SEXP _rvinecopulib_vinecop_rosenblatt_cpp(SEXP USEXP, SEXP vinecop_rSEXP, SEXP coresSEXP, SEXP randomize_discreteSEXP, SEXP seedsSEXP) {
+Eigen::MatrixXd vinecop_rosenblatt_cpp(const Eigen::MatrixXd& U, const Rcpp::List& vinecop_r, const std::vector<size_t>& conditioning_set, size_t cores, bool randomize_discrete, std::vector<int> seeds);
+RcppExport SEXP _rvinecopulib_vinecop_rosenblatt_cpp(SEXP USEXP, SEXP vinecop_rSEXP, SEXP conditioning_setSEXP, SEXP coresSEXP, SEXP randomize_discreteSEXP, SEXP seedsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type U(USEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type vinecop_r(vinecop_rSEXP);
+    Rcpp::traits::input_parameter< const std::vector<size_t>& >::type conditioning_set(conditioning_setSEXP);
     Rcpp::traits::input_parameter< size_t >::type cores(coresSEXP);
     Rcpp::traits::input_parameter< bool >::type randomize_discrete(randomize_discreteSEXP);
     Rcpp::traits::input_parameter< std::vector<int> >::type seeds(seedsSEXP);
-    rcpp_result_gen = Rcpp::wrap(vinecop_rosenblatt_cpp(U, vinecop_r, cores, randomize_discrete, seeds));
+    rcpp_result_gen = Rcpp::wrap(vinecop_rosenblatt_cpp(U, vinecop_r, conditioning_set, cores, randomize_discrete, seeds));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -465,8 +467,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rvinecopulib_rvine_structure_sim_cpp", (DL_FUNC) &_rvinecopulib_rvine_structure_sim_cpp, 3},
     {"_rvinecopulib_rvine_matrix_check_cpp", (DL_FUNC) &_rvinecopulib_rvine_matrix_check_cpp, 1},
     {"_rvinecopulib_vinecop_check_cpp", (DL_FUNC) &_rvinecopulib_vinecop_check_cpp, 1},
-    {"_rvinecopulib_vinecop_inverse_rosenblatt_cpp", (DL_FUNC) &_rvinecopulib_vinecop_inverse_rosenblatt_cpp, 3},
-    {"_rvinecopulib_vinecop_rosenblatt_cpp", (DL_FUNC) &_rvinecopulib_vinecop_rosenblatt_cpp, 5},
+    {"_rvinecopulib_vinecop_inverse_rosenblatt_cpp", (DL_FUNC) &_rvinecopulib_vinecop_inverse_rosenblatt_cpp, 4},
+    {"_rvinecopulib_vinecop_rosenblatt_cpp", (DL_FUNC) &_rvinecopulib_vinecop_rosenblatt_cpp, 6},
     {"_rvinecopulib_vinecop_sim_cpp", (DL_FUNC) &_rvinecopulib_vinecop_sim_cpp, 5},
     {"_rvinecopulib_vinecop_sim_conditional_cpp", (DL_FUNC) &_rvinecopulib_vinecop_sim_conditional_cpp, 6},
     {"_rvinecopulib_vinecop_pdf_cpp", (DL_FUNC) &_rvinecopulib_vinecop_pdf_cpp, 3},

--- a/src/vinecopulib-interface.cpp
+++ b/src/vinecopulib-interface.cpp
@@ -235,19 +235,32 @@ void vinecop_check_cpp(Rcpp::List vinecop_r)
 // [[Rcpp::export()]]
 Eigen::MatrixXd vinecop_inverse_rosenblatt_cpp(const Eigen::MatrixXd& U,
                                                const Rcpp::List& vinecop_r,
+                                               const std::vector<size_t>&
+                                                 conditioning_set,
                                                size_t cores)
 {
-  return vinecop_wrap(vinecop_r).inverse_rosenblatt(U, cores);
+  Vinecop vinecop_cpp = vinecop_wrap(vinecop_r);
+  if (conditioning_set.empty()) {
+    return vinecop_cpp.inverse_rosenblatt(U, cores);
+  }
+  return vinecop_cpp.inverse_rosenblatt(U, conditioning_set, cores);
 }
 
 // [[Rcpp::export()]]
 Eigen::MatrixXd vinecop_rosenblatt_cpp(const Eigen::MatrixXd& U,
                                        const Rcpp::List& vinecop_r,
+                                       const std::vector<size_t>&
+                                         conditioning_set,
                                        size_t cores,
                                        bool randomize_discrete,
                                        std::vector<int> seeds)
 {
-  return vinecop_wrap(vinecop_r).rosenblatt(U, cores, randomize_discrete, seeds);
+  Vinecop vinecop_cpp = vinecop_wrap(vinecop_r);
+  if (conditioning_set.empty()) {
+    return vinecop_cpp.rosenblatt(U, cores, randomize_discrete, seeds);
+  }
+  return vinecop_cpp.rosenblatt(
+    U, conditioning_set, cores, randomize_discrete, seeds);
 }
 
 // [[Rcpp::export()]]

--- a/tests/testthat/test_rosenblatt.R
+++ b/tests/testthat/test_rosenblatt.R
@@ -24,6 +24,129 @@ test_that("rosenblatt works with vine copulas", {
   expect_eql(inverse_rosenblatt(rosenblatt(u, vc), vc), u)
 })
 
+test_that("rosenblatt supports explicit conditioning sets", {
+  indep <- bicop_dist()
+  vc_cond <- vinecop_dist(
+    list(rep(list(indep), 3), rep(list(indep), 2), list(indep)),
+    dvine_structure(1:4)
+  )
+  vc_cond$names <- letters[1:4]
+  structure_before <- vc_cond$structure
+  u <- rvinecop(20, vc_cond)
+
+  z_names <- rosenblatt(
+    u,
+    vc_cond,
+    conditioning_set = c("d", "c")
+  )
+  z_indices <- rosenblatt(u, vc_cond, conditioning_set = c(4, 3))
+  expect_identical(z_names, z_indices)
+  expect_identical(colnames(z_names), letters[1:4])
+  expect_equal(
+    inverse_rosenblatt(
+      z_names,
+      vc_cond,
+      conditioning_set = c("d", "c")
+    ),
+    u
+  )
+  expect_identical(
+    rosenblatt(u, vc_cond, cores = 2, conditioning_set = c(4, 3)),
+    z_indices
+  )
+  expect_identical(
+    inverse_rosenblatt(
+      z_indices,
+      vc_cond,
+      cores = 2,
+      conditioning_set = c(4, 3)
+    ),
+    u
+  )
+  expect_identical(vc_cond$structure, structure_before)
+
+  u_bicop <- rbicop(20, pc)
+  expect_equal(
+    inverse_rosenblatt(
+      rosenblatt(u_bicop, pc, conditioning_set = 1),
+      pc,
+      conditioning_set = 1
+    ),
+    u_bicop
+  )
+})
+
+test_that("conditional rosenblatt safeguards are enforced", {
+  indep <- bicop_dist()
+  vc_cond <- vinecop_dist(
+    list(rep(list(indep), 2), list(indep)),
+    dvine_structure(1:3)
+  )
+  u <- matrix(runif(15), ncol = 3)
+
+  expect_error(
+    rosenblatt(u, vc_cond, conditioning_set = "a"),
+    "requires named variables"
+  )
+  vc_cond$names <- letters[1:3]
+  expect_error(
+    rosenblatt(u, vc_cond, conditioning_set = "unknown"),
+    "unknown variable names"
+  )
+  expect_error(
+    inverse_rosenblatt(u, vc_cond, conditioning_set = c(1, 1)),
+    "must not contain duplicates"
+  )
+  expect_error(
+    rosenblatt(u, vc_cond, conditioning_set = 0),
+    "between 1 and d"
+  )
+  expect_error(
+    inverse_rosenblatt(u, vc_cond, conditioning_set = 1:3),
+    "at most d - 1"
+  )
+  expect_error(
+    rosenblatt(u, vc_cond, conditioning_set = 1.5),
+    "indices or names"
+  )
+  expect_error(rosenblatt(u, vc_cond, cores = 0), "not greater than 0")
+  expect_error(inverse_rosenblatt(u, vc_cond, cores = 0), "not greater than 0")
+  expect_error(
+    rosenblatt(u, vc_cond, randomize_discrete = 1),
+    "not a flag"
+  )
+})
+
+test_that("conditional discrete rosenblatt uses R seeds and both layouts", {
+  indep <- bicop_dist()
+  vc_disc <- vinecop_dist(
+    list(rep(list(indep), 2), list(indep)),
+    dvine_structure(1:3),
+    var_types = c("c", "d", "c")
+  )
+  u <- matrix(seq(0.15, 0.85, length.out = 30), ncol = 3)
+  u_lower <- pmax(u[, 2] - 0.1, 1e-10)
+  compact <- cbind(u, u_lower)
+  expanded <- cbind(u, u)
+  expanded[, 5] <- u_lower
+
+  set.seed(314)
+  z_compact <- rosenblatt(compact, vc_disc, conditioning_set = 2)
+  state_after <- .Random.seed
+  set.seed(314)
+  z_expanded <- rosenblatt(expanded, vc_disc, conditioning_set = 2)
+  expect_identical(z_expanded, z_compact)
+  expect_identical(.Random.seed, state_after)
+
+  set.seed(314)
+  runif(20)
+  expect_identical(.Random.seed, state_after)
+
+  set.seed(315)
+  z_other_seed <- rosenblatt(compact, vc_disc, conditioning_set = 2)
+  expect_false(identical(z_other_seed[, 2], z_compact[, 2]))
+})
+
 test_that("discrete rosenblatt works with vine copulas", {
   u <- rvinecop(2000, vc)
   uu <- cbind(u, u[, 2])
@@ -56,6 +179,15 @@ test_that("rosenblatt works with vine distribution", {
   expect_eql(inverse_rosenblatt(rosenblatt(u, vd), vd), u)
   vd <- vine(u, copula_controls = list(structure = mat, family = "clay"))
   expect_equiv(inverse_rosenblatt(rosenblatt(u, vd), vd), u)
+
+  vd$names <- vd$copula$names <- letters[1:3]
+  colnames(u) <- letters[1:3]
+  z <- rosenblatt(u, vd, conditioning_set = "a")
+  expect_identical(colnames(z), letters[1:3])
+  expect_equiv(
+    inverse_rosenblatt(z, vd, conditioning_set = "a"),
+    u
+  )
 })
 
 test_that("discrete rosenblatt works with vine distributions", {


### PR DESCRIPTION
## Summary

- add `conditioning_set` to `rosenblatt()` and `inverse_rosenblatt()`
- accept 1-based variable indices or model variable names
- use the backend's transient reorientation overloads without modifying the model
- support `bicop_dist`, `vinecop_dist`, and `vine_dist` models
- retain compact and expanded discrete-data layouts

## API decisions

The new argument is appended to preserve positional compatibility:

```r
rosenblatt(
  x,
  model,
  cores = 1,
  randomize_discrete = TRUE,
  conditioning_set = NULL
)

inverse_rosenblatt(u, model, cores = 1, conditioning_set = NULL)
```

- `conditioning_set = NULL` retains the current model order and existing behavior
- a supplied set must contain between one and `d - 1` unique variables
- character sets require unique model variable names
- the backend selects an admissible order whose tail contains exactly the set
- reorientation is deliberately not exposed as a separate public mutating API

## Tests

Added coverage for:

- forward/inverse round trips with numeric and named conditioning sets
- bivariate copula, vine copula, and full vine-distribution models
- equality between one- and two-thread evaluation
- preservation of model structure and output names
- compact versus expanded discrete layouts
- deterministic discrete randomization under `set.seed()`
- exact R RNG advancement by the 20 seed draws passed to C++
- changed randomized values under a different R seed
- unnamed/unknown variables, duplicates, non-integer and out-of-range indices, full-dimensional sets, invalid core counts, and invalid randomization flags

Results on this stack:

- focused Rosenblatt tests: 32 passed
- full testthat suite at this layer: 708 passed, 0 failures, warnings, or skips
- full release-stack suite: 817 passed and `R CMD check` reported **Status: OK**

This PR is stacked on #323 because it reuses the conditioning-set validation introduced by conditional simulation.

<sub>Managed as part of GitHub stack #330.</sub>
