### PR TITLE
Expose density and h-function derivatives

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,9 @@ for the complete backend changes.
   for vine copulas. They support observation-specific parameter matrices for
   continuous parametric models.
 
+* Add first- and second-order density, log-density, and h-function derivatives
+  to `dbicop()` and `hbicop()` through the `deriv` argument.
+
 * Add `keep_all` to `dvinecop()` to return per-edge densities and h-functions,
   and allow observation-specific parameters in `dvinecop()`.
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,28 +13,32 @@ bicop_select_cpp <- function(data, family_set, par_method, nonpar_method, mult, 
     .Call(`_rvinecopulib_bicop_select_cpp`, data, family_set, par_method, nonpar_method, mult, selcrit, weights, psi0, presel, num_threads, allow_rotations, var_types)
 }
 
-bicop_pdf_cpp <- function(u, bicop_r) {
-    .Call(`_rvinecopulib_bicop_pdf_cpp`, u, bicop_r)
+bicop_pdf_cpp <- function(u, bicop_r, cores = 1L) {
+    .Call(`_rvinecopulib_bicop_pdf_cpp`, u, bicop_r, cores)
 }
 
 bicop_cdf_cpp <- function(u, bicop_r) {
     .Call(`_rvinecopulib_bicop_cdf_cpp`, u, bicop_r)
 }
 
-bicop_hfunc1_cpp <- function(u, bicop_r) {
-    .Call(`_rvinecopulib_bicop_hfunc1_cpp`, u, bicop_r)
+bicop_hfunc1_cpp <- function(u, bicop_r, cores = 1L) {
+    .Call(`_rvinecopulib_bicop_hfunc1_cpp`, u, bicop_r, cores)
 }
 
-bicop_hfunc2_cpp <- function(u, bicop_r) {
-    .Call(`_rvinecopulib_bicop_hfunc2_cpp`, u, bicop_r)
+bicop_hfunc2_cpp <- function(u, bicop_r, cores = 1L) {
+    .Call(`_rvinecopulib_bicop_hfunc2_cpp`, u, bicop_r, cores)
 }
 
-bicop_hinv1_cpp <- function(u, bicop_r) {
-    .Call(`_rvinecopulib_bicop_hinv1_cpp`, u, bicop_r)
+bicop_hinv1_cpp <- function(u, bicop_r, cores = 1L) {
+    .Call(`_rvinecopulib_bicop_hinv1_cpp`, u, bicop_r, cores)
 }
 
-bicop_hinv2_cpp <- function(u, bicop_r) {
-    .Call(`_rvinecopulib_bicop_hinv2_cpp`, u, bicop_r)
+bicop_hinv2_cpp <- function(u, bicop_r, cores = 1L) {
+    .Call(`_rvinecopulib_bicop_hinv2_cpp`, u, bicop_r, cores)
+}
+
+bicop_deriv_cpp <- function(u, bicop_r, what, deriv, order, cores) {
+    .Call(`_rvinecopulib_bicop_deriv_cpp`, u, bicop_r, what, deriv, order, cores)
 }
 
 bicop_sim_cpp <- function(bicop_r, n, qrng, seeds) {

--- a/R/bicop_methods.R
+++ b/R/bicop_methods.R
@@ -143,7 +143,14 @@ dbicop <- function(
   }
 
   what <- if (log) "logpdf" else "pdf"
-  bicop_deriv_cpp(u, bicop, what, paste0(deriv, collapse = ""), length(deriv), cores)
+  bicop_deriv_cpp(
+    u,
+    bicop,
+    what,
+    paste0(deriv, collapse = ""),
+    length(deriv),
+    cores
+  )
 }
 #' @rdname bicop_methods
 #' @export

--- a/R/bicop_methods.R
+++ b/R/bicop_methods.R
@@ -19,7 +19,13 @@
 #' @param var_types variable types, a length 2 vector; e.g., `c("c", "c")` for
 #'   both continuous (default), or `c("c", "d")` for first variable continuous
 #'   and second discrete.
-#' @param cores number of cores used for derivatives with per-observation
+#' @param log whether to return the log-density or a derivative of the
+#'   log-density.
+#' @param deriv `NULL` for ordinary evaluation, or a character vector of length
+#'   one or two specifying a first- or second-order partial derivative. Each
+#'   component is one of `"u1"`, `"u2"`, or `"par<k>"`; `"par"` is an alias
+#'   for `"par1"`.
+#' @param cores number of cores used when evaluating observation-specific
 #'   parameters.
 #' @param vinecop a `bicop_dist` object for `scores()` and `hessian()`.
 #' @param ... unused.
@@ -43,6 +49,20 @@
 #' When inverting H-functions, the inverse is then taken with respect to the
 #' other variable, that is `v` when `cond_var = 1` and `u` when `cond_var = 2`.
 #'
+#' ## Derivatives
+#'
+#' Setting `deriv` evaluates a selected first- or second-order derivative of
+#' the density, log-density, or h-function. For example, `deriv = "u1"`
+#' differentiates with respect to the first argument and
+#' `deriv = c("u1", "par2")` evaluates the corresponding mixed second
+#' derivative. Derivative order is immaterial. Parameter derivatives use the
+#' natural parameters of the (possibly rotated) copula.
+#'
+#' Derivatives are available only for continuous parametric copulas. The
+#' backend uses analytic formulas where available and finite-difference
+#' fallbacks where needed. Derivatives of inverse h-functions are not
+#' available.
+#'
 #' ## Discrete variables
 #' When at least one variable is discrete, more than two columns are required
 #' for `u`: the first \eqn{n \times 2} block contains realizations of
@@ -54,10 +74,13 @@
 #' second block.
 #'
 #' @return
-#' `dbicop()` gives the density, `pbicop()` gives the distribution function,
+#' `dbicop()` gives the density or log-density, and `pbicop()` gives the
+#' distribution function.
 #' `rbicop()` generates random deviates, and `hbicop()` gives the h-functions
-#' (and their inverses). `scores()` gives the observation-wise score matrix and
-#' `hessian()` gives the average Hessian matrix for a `bicop_dist` object.
+#' (and their inverses). If `deriv` is set, `dbicop()` and `hbicop()` return
+#' the selected observation-wise derivative. `scores()` gives the
+#' observation-wise score matrix and `hessian()` gives the average Hessian
+#' matrix for a `bicop_dist` object.
 #'
 #' The length of the result is determined by `n` for `rbicop()`, and
 #' the number of rows in `u` for the other functions.
@@ -87,6 +110,11 @@
 #' # h_2^{-1}(0.1, 0.2)
 #' hbicop(c(0.1, 0.2), 2, joe_cop, inverse = TRUE)
 #'
+#' ## derivatives
+#' dbicop(c(0.2, 0.4), joe_cop, deriv = "u1")
+#' dbicop(c(0.2, 0.4), joe_cop, log = TRUE, deriv = "par1")
+#' hbicop(c(0.2, 0.4), 1, joe_cop, deriv = c("u1", "par1"))
+#'
 #' ## mixed discrete and continuous data
 #' x <- cbind(rpois(10, 1), rnorm(10, 1))
 #' u <- cbind(ppois(x[, 1], 1), pnorm(x[, 2]), ppois(x[, 1] - 1, 1))
@@ -94,10 +122,28 @@
 #'
 #' @rdname bicop_methods
 #' @export
-dbicop <- function(u, family, rotation, parameters, var_types = c("c", "c")) {
+dbicop <- function(
+  u,
+  family,
+  rotation,
+  parameters,
+  var_types = c("c", "c"),
+  log = FALSE,
+  deriv = NULL,
+  cores = 1
+) {
+  assert_that(is.flag(log), is.number(cores), cores > 0)
+  deriv <- normalize_bicop_deriv(deriv)
   u <- if_vec_to_matrix(u)
   bicop <- args2bicop(family, rotation, parameters, var_types)
-  bicop_pdf_cpp(u, bicop)
+
+  if (is.null(deriv)) {
+    density <- bicop_pdf_cpp(u, bicop, cores)
+    return(if (log) base::log(density) else density)
+  }
+
+  what <- if (log) "logpdf" else "pdf"
+  bicop_deriv_cpp(u, bicop, what, paste0(deriv, collapse = ""), length(deriv), cores)
 }
 #' @rdname bicop_methods
 #' @export
@@ -180,23 +226,46 @@ hbicop <- function(
   rotation,
   parameters,
   inverse = FALSE,
-  var_types = c("c", "c")
+  var_types = c("c", "c"),
+  deriv = NULL,
+  cores = 1
 ) {
-  assert_that(in_set(cond_var, 1:2), is.flag(inverse))
+  assert_that(
+    in_set(cond_var, 1:2),
+    is.flag(inverse),
+    is.number(cores),
+    cores > 0
+  )
+  deriv <- normalize_bicop_deriv(deriv)
+  if (inverse && !is.null(deriv)) {
+    stop("derivatives of inverse h-functions are not available.", call. = FALSE)
+  }
   bicop <- args2bicop(family, rotation, parameters, var_types)
   u <- if_vec_to_matrix(u)
 
+  if (!is.null(deriv)) {
+    what <- if (cond_var == 1) "hfunc1" else "hfunc2"
+    return(bicop_deriv_cpp(
+      u,
+      bicop,
+      what,
+      paste0(deriv, collapse = ""),
+      length(deriv),
+      cores
+    ))
+  }
+
   if (!inverse) {
     if (cond_var == 1) {
-      return(bicop_hfunc1_cpp(u, bicop))
+      return(bicop_hfunc1_cpp(u, bicop, cores))
     } else {
-      return(bicop_hfunc2_cpp(u, bicop))
+      return(bicop_hfunc2_cpp(u, bicop, cores))
     }
   } else {
     if (cond_var == 1) {
-      return(bicop_hinv1_cpp(u, bicop))
+      return(bicop_hinv1_cpp(u, bicop, cores))
     } else {
-      return(bicop_hinv2_cpp(u, bicop))
+      return(bicop_hinv2_cpp(u, bicop, cores))
     }
   }
 }

--- a/R/tools.R
+++ b/R/tools.R
@@ -180,6 +180,33 @@ is_vectorized_bicop_parameters <- function(parameters, family) {
   TRUE
 }
 
+#' Internal: Validate a bivariate copula derivative selector.
+#' @param deriv character vector identifying one or two differentiation
+#'   components.
+#' @return The normalized components, or `NULL`.
+#' @noRd
+normalize_bicop_deriv <- function(deriv) {
+  if (is.null(deriv)) {
+    return(NULL)
+  }
+  if (!is.character(deriv) || !length(deriv) %in% 1:2 || anyNA(deriv)) {
+    stop(
+      "'deriv' must be NULL or a character vector of length one or two.",
+      call. = FALSE
+    )
+  }
+
+  deriv[deriv == "par"] <- "par1"
+  valid <- grepl("^(u1|u2|par[1-9][0-9]*)$", deriv)
+  if (!all(valid)) {
+    stop(
+      "components of 'deriv' must be 'u1', 'u2', 'par', or 'par<k>'.",
+      call. = FALSE
+    )
+  }
+  deriv
+}
+
 process_family_set <- function(family_set, par_method) {
   family_set <- check_and_match_family_set(family_set)
   family_set <- expand_family_set(family_set)

--- a/man/bicop_methods.Rd
+++ b/man/bicop_methods.Rd
@@ -14,7 +14,16 @@
 \alias{hessian.bicop_dist}
 \title{Bivariate copula distributions}
 \usage{
-dbicop(u, family, rotation, parameters, var_types = c("c", "c"))
+dbicop(
+  u,
+  family,
+  rotation,
+  parameters,
+  var_types = c("c", "c"),
+  log = FALSE,
+  deriv = NULL,
+  cores = 1
+)
 
 pbicop(u, family, rotation, parameters, var_types = c("c", "c"))
 
@@ -31,7 +40,9 @@ hbicop(
   rotation,
   parameters,
   inverse = FALSE,
-  var_types = c("c", "c")
+  var_types = c("c", "c"),
+  deriv = NULL,
+  cores = 1
 )
 }
 \arguments{
@@ -53,6 +64,17 @@ parameter. Parameters are not recycled.}
 both continuous (default), or \code{c("c", "d")} for first variable continuous
 and second discrete.}
 
+\item{log}{whether to return the log-density or a derivative of the
+log-density.}
+
+\item{deriv}{\code{NULL} for ordinary evaluation, or a character vector of length
+one or two specifying a first- or second-order partial derivative. Each
+component is one of \code{"u1"}, \code{"u2"}, or \code{"par<k>"}; \code{"par"} is an alias
+for \code{"par1"}.}
+
+\item{cores}{number of cores used when evaluating observation-specific
+parameters.}
+
 \item{n}{number of observations. If `length(n) > 1``, the length is taken to
 be the number required.}
 
@@ -60,9 +82,6 @@ be the number required.}
 Generalized Halton sequence (default \code{qrng = FALSE}).}
 
 \item{vinecop}{a \code{bicop_dist} object for \code{scores()} and \code{hessian()}.}
-
-\item{cores}{number of cores used for derivatives with per-observation
-parameters.}
 
 \item{...}{unused.}
 
@@ -72,10 +91,13 @@ variable, \code{cond_var = 2} on the second.}
 \item{inverse}{whether to compute the h-function or its inverse.}
 }
 \value{
-\code{dbicop()} gives the density, \code{pbicop()} gives the distribution function,
+\code{dbicop()} gives the density or log-density, and \code{pbicop()} gives the
+distribution function.
 \code{rbicop()} generates random deviates, and \code{hbicop()} gives the h-functions
-(and their inverses). \code{scores()} gives the observation-wise score matrix and
-\code{hessian()} gives the average Hessian matrix for a \code{bicop_dist} object.
+(and their inverses). If \code{deriv} is set, \code{dbicop()} and \code{hbicop()} return
+the selected observation-wise derivative. \code{scores()} gives the
+observation-wise score matrix and \code{hessian()} gives the average Hessian
+matrix for a \code{bicop_dist} object.
 
 The length of the result is determined by \code{n} for \code{rbicop()}, and
 the number of rows in \code{u} for the other functions.
@@ -102,6 +124,21 @@ from a copula. If \eqn{C(u, v) = P(U \le u, V \le v)} is a copula, then
 In other words, the H-function number refers to the conditioning variable.
 When inverting H-functions, the inverse is then taken with respect to the
 other variable, that is \code{v} when \code{cond_var = 1} and \code{u} when \code{cond_var = 2}.
+\subsection{Derivatives}{
+
+Setting \code{deriv} evaluates a selected first- or second-order derivative of
+the density, log-density, or h-function. For example, \code{deriv = "u1"}
+differentiates with respect to the first argument and
+\code{deriv = c("u1", "par2")} evaluates the corresponding mixed second
+derivative. Derivative order is immaterial. Parameter derivatives use the
+natural parameters of the (possibly rotated) copula.
+
+Derivatives are available only for continuous parametric copulas. The
+backend uses analytic formulas where available and finite-difference
+fallbacks where needed. Derivatives of inverse h-functions are not
+available.
+}
+
 \subsection{Discrete variables}{
 
 When at least one variable is discrete, more than two columns are required
@@ -137,6 +174,11 @@ joe_cop <- bicop_dist("joe", 0, 3)
 hbicop(c(0.1, 0.2), 1, "bb8", 0, c(2, 0.5))
 # h_2^{-1}(0.1, 0.2)
 hbicop(c(0.1, 0.2), 2, joe_cop, inverse = TRUE)
+
+## derivatives
+dbicop(c(0.2, 0.4), joe_cop, deriv = "u1")
+dbicop(c(0.2, 0.4), joe_cop, log = TRUE, deriv = "par1")
+hbicop(c(0.2, 0.4), 1, joe_cop, deriv = c("u1", "par1"))
 
 ## mixed discrete and continuous data
 x <- cbind(rpois(10, 1), rnorm(10, 1))

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -57,14 +57,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // bicop_pdf_cpp
-Eigen::VectorXd bicop_pdf_cpp(const Eigen::MatrixXd& u, const Rcpp::List& bicop_r);
-RcppExport SEXP _rvinecopulib_bicop_pdf_cpp(SEXP uSEXP, SEXP bicop_rSEXP) {
+Eigen::VectorXd bicop_pdf_cpp(const Eigen::MatrixXd& u, const Rcpp::List& bicop_r, const size_t cores);
+RcppExport SEXP _rvinecopulib_bicop_pdf_cpp(SEXP uSEXP, SEXP bicop_rSEXP, SEXP coresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type u(uSEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type bicop_r(bicop_rSEXP);
-    rcpp_result_gen = Rcpp::wrap(bicop_pdf_cpp(u, bicop_r));
+    Rcpp::traits::input_parameter< const size_t >::type cores(coresSEXP);
+    rcpp_result_gen = Rcpp::wrap(bicop_pdf_cpp(u, bicop_r, cores));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -81,50 +82,70 @@ BEGIN_RCPP
 END_RCPP
 }
 // bicop_hfunc1_cpp
-Eigen::VectorXd bicop_hfunc1_cpp(const Eigen::MatrixXd& u, const Rcpp::List& bicop_r);
-RcppExport SEXP _rvinecopulib_bicop_hfunc1_cpp(SEXP uSEXP, SEXP bicop_rSEXP) {
+Eigen::VectorXd bicop_hfunc1_cpp(const Eigen::MatrixXd& u, const Rcpp::List& bicop_r, const size_t cores);
+RcppExport SEXP _rvinecopulib_bicop_hfunc1_cpp(SEXP uSEXP, SEXP bicop_rSEXP, SEXP coresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type u(uSEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type bicop_r(bicop_rSEXP);
-    rcpp_result_gen = Rcpp::wrap(bicop_hfunc1_cpp(u, bicop_r));
+    Rcpp::traits::input_parameter< const size_t >::type cores(coresSEXP);
+    rcpp_result_gen = Rcpp::wrap(bicop_hfunc1_cpp(u, bicop_r, cores));
     return rcpp_result_gen;
 END_RCPP
 }
 // bicop_hfunc2_cpp
-Eigen::VectorXd bicop_hfunc2_cpp(const Eigen::MatrixXd& u, const Rcpp::List& bicop_r);
-RcppExport SEXP _rvinecopulib_bicop_hfunc2_cpp(SEXP uSEXP, SEXP bicop_rSEXP) {
+Eigen::VectorXd bicop_hfunc2_cpp(const Eigen::MatrixXd& u, const Rcpp::List& bicop_r, const size_t cores);
+RcppExport SEXP _rvinecopulib_bicop_hfunc2_cpp(SEXP uSEXP, SEXP bicop_rSEXP, SEXP coresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type u(uSEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type bicop_r(bicop_rSEXP);
-    rcpp_result_gen = Rcpp::wrap(bicop_hfunc2_cpp(u, bicop_r));
+    Rcpp::traits::input_parameter< const size_t >::type cores(coresSEXP);
+    rcpp_result_gen = Rcpp::wrap(bicop_hfunc2_cpp(u, bicop_r, cores));
     return rcpp_result_gen;
 END_RCPP
 }
 // bicop_hinv1_cpp
-Eigen::VectorXd bicop_hinv1_cpp(const Eigen::MatrixXd& u, const Rcpp::List& bicop_r);
-RcppExport SEXP _rvinecopulib_bicop_hinv1_cpp(SEXP uSEXP, SEXP bicop_rSEXP) {
+Eigen::VectorXd bicop_hinv1_cpp(const Eigen::MatrixXd& u, const Rcpp::List& bicop_r, const size_t cores);
+RcppExport SEXP _rvinecopulib_bicop_hinv1_cpp(SEXP uSEXP, SEXP bicop_rSEXP, SEXP coresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type u(uSEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type bicop_r(bicop_rSEXP);
-    rcpp_result_gen = Rcpp::wrap(bicop_hinv1_cpp(u, bicop_r));
+    Rcpp::traits::input_parameter< const size_t >::type cores(coresSEXP);
+    rcpp_result_gen = Rcpp::wrap(bicop_hinv1_cpp(u, bicop_r, cores));
     return rcpp_result_gen;
 END_RCPP
 }
 // bicop_hinv2_cpp
-Eigen::VectorXd bicop_hinv2_cpp(const Eigen::MatrixXd& u, const Rcpp::List& bicop_r);
-RcppExport SEXP _rvinecopulib_bicop_hinv2_cpp(SEXP uSEXP, SEXP bicop_rSEXP) {
+Eigen::VectorXd bicop_hinv2_cpp(const Eigen::MatrixXd& u, const Rcpp::List& bicop_r, const size_t cores);
+RcppExport SEXP _rvinecopulib_bicop_hinv2_cpp(SEXP uSEXP, SEXP bicop_rSEXP, SEXP coresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type u(uSEXP);
     Rcpp::traits::input_parameter< const Rcpp::List& >::type bicop_r(bicop_rSEXP);
-    rcpp_result_gen = Rcpp::wrap(bicop_hinv2_cpp(u, bicop_r));
+    Rcpp::traits::input_parameter< const size_t >::type cores(coresSEXP);
+    rcpp_result_gen = Rcpp::wrap(bicop_hinv2_cpp(u, bicop_r, cores));
+    return rcpp_result_gen;
+END_RCPP
+}
+// bicop_deriv_cpp
+Eigen::VectorXd bicop_deriv_cpp(const Eigen::MatrixXd& u, const Rcpp::List& bicop_r, const std::string& what, const std::string& deriv, const size_t order, const size_t cores);
+RcppExport SEXP _rvinecopulib_bicop_deriv_cpp(SEXP uSEXP, SEXP bicop_rSEXP, SEXP whatSEXP, SEXP derivSEXP, SEXP orderSEXP, SEXP coresSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type u(uSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::List& >::type bicop_r(bicop_rSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type what(whatSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type deriv(derivSEXP);
+    Rcpp::traits::input_parameter< const size_t >::type order(orderSEXP);
+    Rcpp::traits::input_parameter< const size_t >::type cores(coresSEXP);
+    rcpp_result_gen = Rcpp::wrap(bicop_deriv_cpp(u, bicop_r, what, deriv, order, cores));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -484,12 +505,13 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rvinecopulib_pseudo_obs_cpp", (DL_FUNC) &_rvinecopulib_pseudo_obs_cpp, 2},
     {"_rvinecopulib_bicop_check_cpp", (DL_FUNC) &_rvinecopulib_bicop_check_cpp, 1},
     {"_rvinecopulib_bicop_select_cpp", (DL_FUNC) &_rvinecopulib_bicop_select_cpp, 12},
-    {"_rvinecopulib_bicop_pdf_cpp", (DL_FUNC) &_rvinecopulib_bicop_pdf_cpp, 2},
+    {"_rvinecopulib_bicop_pdf_cpp", (DL_FUNC) &_rvinecopulib_bicop_pdf_cpp, 3},
     {"_rvinecopulib_bicop_cdf_cpp", (DL_FUNC) &_rvinecopulib_bicop_cdf_cpp, 2},
-    {"_rvinecopulib_bicop_hfunc1_cpp", (DL_FUNC) &_rvinecopulib_bicop_hfunc1_cpp, 2},
-    {"_rvinecopulib_bicop_hfunc2_cpp", (DL_FUNC) &_rvinecopulib_bicop_hfunc2_cpp, 2},
-    {"_rvinecopulib_bicop_hinv1_cpp", (DL_FUNC) &_rvinecopulib_bicop_hinv1_cpp, 2},
-    {"_rvinecopulib_bicop_hinv2_cpp", (DL_FUNC) &_rvinecopulib_bicop_hinv2_cpp, 2},
+    {"_rvinecopulib_bicop_hfunc1_cpp", (DL_FUNC) &_rvinecopulib_bicop_hfunc1_cpp, 3},
+    {"_rvinecopulib_bicop_hfunc2_cpp", (DL_FUNC) &_rvinecopulib_bicop_hfunc2_cpp, 3},
+    {"_rvinecopulib_bicop_hinv1_cpp", (DL_FUNC) &_rvinecopulib_bicop_hinv1_cpp, 3},
+    {"_rvinecopulib_bicop_hinv2_cpp", (DL_FUNC) &_rvinecopulib_bicop_hinv2_cpp, 3},
+    {"_rvinecopulib_bicop_deriv_cpp", (DL_FUNC) &_rvinecopulib_bicop_deriv_cpp, 6},
     {"_rvinecopulib_bicop_sim_cpp", (DL_FUNC) &_rvinecopulib_bicop_sim_cpp, 4},
     {"_rvinecopulib_bicop_scores_cpp", (DL_FUNC) &_rvinecopulib_bicop_scores_cpp, 4},
     {"_rvinecopulib_bicop_hessian_cpp", (DL_FUNC) &_rvinecopulib_bicop_hessian_cpp, 4},

--- a/src/vinecopulib-interface.cpp
+++ b/src/vinecopulib-interface.cpp
@@ -84,12 +84,13 @@ Rcpp::List bicop_select_cpp(const Eigen::MatrixXd& data,
 
 // [[Rcpp::export()]]
 Eigen::VectorXd bicop_pdf_cpp(const Eigen::MatrixXd& u,
-                              const Rcpp::List& bicop_r)
+                              const Rcpp::List& bicop_r,
+                              const size_t cores = 1)
 {
   Bicop bicop_cpp = bicop_wrap(bicop_r);
   Eigen::MatrixXd parameters = get_bicop_parameters(bicop_r);
   if (has_vectorized_bicop_parameters(bicop_cpp, parameters)) {
-    return bicop_cpp.pdf(u, parameters);
+    return bicop_cpp.pdf(u, parameters, cores);
   }
   return bicop_cpp.pdf(u);
 }
@@ -108,50 +109,107 @@ Eigen::VectorXd bicop_cdf_cpp(const Eigen::MatrixXd& u,
 
 // [[Rcpp::export()]]
 Eigen::VectorXd bicop_hfunc1_cpp(const Eigen::MatrixXd& u,
-                                 const Rcpp::List& bicop_r)
+                                 const Rcpp::List& bicop_r,
+                                 const size_t cores = 1)
 {
   Bicop bicop_cpp = bicop_wrap(bicop_r);
   Eigen::MatrixXd parameters = get_bicop_parameters(bicop_r);
   if (has_vectorized_bicop_parameters(bicop_cpp, parameters)) {
-    return bicop_cpp.hfunc1(u, parameters);
+    return bicop_cpp.hfunc1(u, parameters, cores);
   }
   return bicop_cpp.hfunc1(u);
 }
 
 // [[Rcpp::export()]]
 Eigen::VectorXd bicop_hfunc2_cpp(const Eigen::MatrixXd& u,
-                                 const Rcpp::List& bicop_r)
+                                 const Rcpp::List& bicop_r,
+                                 const size_t cores = 1)
 {
   Bicop bicop_cpp = bicop_wrap(bicop_r);
   Eigen::MatrixXd parameters = get_bicop_parameters(bicop_r);
   if (has_vectorized_bicop_parameters(bicop_cpp, parameters)) {
-    return bicop_cpp.hfunc2(u, parameters);
+    return bicop_cpp.hfunc2(u, parameters, cores);
   }
   return bicop_cpp.hfunc2(u);
 }
 
 // [[Rcpp::export()]]
 Eigen::VectorXd bicop_hinv1_cpp(const Eigen::MatrixXd& u,
-                                const Rcpp::List& bicop_r)
+                                const Rcpp::List& bicop_r,
+                                const size_t cores = 1)
 {
   Bicop bicop_cpp = bicop_wrap(bicop_r);
   Eigen::MatrixXd parameters = get_bicop_parameters(bicop_r);
   if (has_vectorized_bicop_parameters(bicop_cpp, parameters)) {
-    return bicop_cpp.hinv1(u, parameters);
+    return bicop_cpp.hinv1(u, parameters, cores);
   }
   return bicop_cpp.hinv1(u);
 }
 
 // [[Rcpp::export()]]
 Eigen::VectorXd bicop_hinv2_cpp(const Eigen::MatrixXd& u,
-                                const Rcpp::List& bicop_r)
+                                const Rcpp::List& bicop_r,
+                                const size_t cores = 1)
 {
   Bicop bicop_cpp = bicop_wrap(bicop_r);
   Eigen::MatrixXd parameters = get_bicop_parameters(bicop_r);
   if (has_vectorized_bicop_parameters(bicop_cpp, parameters)) {
-    return bicop_cpp.hinv2(u, parameters);
+    return bicop_cpp.hinv2(u, parameters, cores);
   }
   return bicop_cpp.hinv2(u);
+}
+
+// [[Rcpp::export()]]
+Eigen::VectorXd bicop_deriv_cpp(const Eigen::MatrixXd& u,
+                                const Rcpp::List& bicop_r,
+                                const std::string& what,
+                                const std::string& deriv,
+                                const size_t order,
+                                const size_t cores)
+{
+  Bicop bicop_cpp = bicop_wrap(bicop_r);
+  Eigen::MatrixXd parameters = get_bicop_parameters(bicop_r);
+  const bool vectorized =
+    has_vectorized_bicop_parameters(bicop_cpp, parameters);
+
+  if ((order != 1) && (order != 2)) {
+    throw std::runtime_error("derivative order must be one or two");
+  }
+
+  if (what == "pdf") {
+    if (vectorized) {
+      return order == 1 ? bicop_cpp.pdf_deriv(u, deriv, parameters, cores)
+                        : bicop_cpp.pdf_deriv2(u, deriv, parameters, cores);
+    }
+    return order == 1 ? bicop_cpp.pdf_deriv(u, deriv)
+                      : bicop_cpp.pdf_deriv2(u, deriv);
+  }
+  if (what == "logpdf") {
+    if (vectorized) {
+      return order == 1 ? bicop_cpp.logpdf_deriv(u, deriv, parameters, cores)
+                        : bicop_cpp.logpdf_deriv2(u, deriv, parameters, cores);
+    }
+    return order == 1 ? bicop_cpp.logpdf_deriv(u, deriv)
+                      : bicop_cpp.logpdf_deriv2(u, deriv);
+  }
+  if (what == "hfunc1") {
+    if (vectorized) {
+      return order == 1 ? bicop_cpp.hfunc1_deriv(u, deriv, parameters, cores)
+                        : bicop_cpp.hfunc1_deriv2(u, deriv, parameters, cores);
+    }
+    return order == 1 ? bicop_cpp.hfunc1_deriv(u, deriv)
+                      : bicop_cpp.hfunc1_deriv2(u, deriv);
+  }
+  if (what == "hfunc2") {
+    if (vectorized) {
+      return order == 1 ? bicop_cpp.hfunc2_deriv(u, deriv, parameters, cores)
+                        : bicop_cpp.hfunc2_deriv2(u, deriv, parameters, cores);
+    }
+    return order == 1 ? bicop_cpp.hfunc2_deriv(u, deriv)
+                      : bicop_cpp.hfunc2_deriv2(u, deriv);
+  }
+
+  throw std::runtime_error("unknown derivative target: " + what);
 }
 
 // [[Rcpp::export()]]

--- a/tests/testthat/test_bicop_dist.R
+++ b/tests/testthat/test_bicop_dist.R
@@ -498,3 +498,204 @@ test_that("bivariate derivative safeguards are enforced", {
     "not implemented for the TLL"
   )
 })
+
+test_that("dbicop exposes selected density derivatives", {
+  u <- matrix(c(0.21, 0.37, 0.44, 0.62, 0.73, 0.28), ncol = 2)
+  cop <- bicop_dist("gaussian", parameters = 0.35)
+  eps <- 1e-6
+
+  u_plus <- u_minus <- u
+  u_plus[, 1] <- u_plus[, 1] + eps
+  u_minus[, 1] <- u_minus[, 1] - eps
+  du1_fd <- (dbicop(u_plus, cop) - dbicop(u_minus, cop)) / (2 * eps)
+
+  expect_equal(dbicop(u, cop, deriv = "u1"), du1_fd, tolerance = 1e-6)
+  expect_equal(
+    dbicop(u, cop, deriv = "par"),
+    dbicop(u, cop, deriv = "par1")
+  )
+  expect_equal(
+    dbicop(u, cop, deriv = c("u1", "par1")),
+    dbicop(u, cop, deriv = c("par1", "u1"))
+  )
+  expect_equal(dbicop(u, cop, log = TRUE), log(dbicop(u, cop)))
+  expect_equal(
+    dbicop(u, cop, log = TRUE, deriv = "par1"),
+    drop(scores(u, cop))
+  )
+  expect_equal(
+    mean(dbicop(u, cop, log = TRUE, deriv = c("par1", "par1"))),
+    drop(hessian(u, cop))
+  )
+})
+
+test_that("hbicop exposes selected h-function derivatives", {
+  u <- matrix(c(0.18, 0.31, 0.47, 0.66, 0.79, 0.23), ncol = 2)
+  cop <- bicop_dist("bb1", rotation = 270, parameters = c(1.2, 1.4))
+  eps <- 1e-6
+
+  cop_plus <- bicop_dist("bb1", 270, c(1.2 + eps, 1.4))
+  cop_minus <- bicop_dist("bb1", 270, c(1.2 - eps, 1.4))
+  dh1_dpar1_fd <-
+    (hbicop(u, 1, cop_plus) - hbicop(u, 1, cop_minus)) / (2 * eps)
+
+  expect_equal(
+    hbicop(u, 1, cop, deriv = "par1"),
+    dh1_dpar1_fd,
+    tolerance = 1e-6
+  )
+  expect_equal(hbicop(u, 1, cop, deriv = "u2"), dbicop(u, cop))
+  expect_equal(hbicop(u, 2, cop, deriv = "u1"), dbicop(u, cop))
+  expect_equal(
+    hbicop(u, 1, cop, deriv = c("par1", "u2")),
+    dbicop(u, cop, deriv = "par1")
+  )
+  expect_equal(
+    hbicop(u, 2, cop, deriv = c("u2", "par2")),
+    hbicop(u, 2, cop, deriv = c("par2", "u2"))
+  )
+})
+
+test_that("function derivatives support observation-specific parameters", {
+  u <- matrix(c(0.2, 0.35, 0.5, 0.65, 0.8, 0.25), ncol = 2)
+  parameters <- matrix(c(-0.5, 0.1, 0.6), ncol = 1)
+  evaluators <- list(
+    function(x, par, cores = 1) {
+      dbicop(x, "gaussian", parameters = par, deriv = "par1", cores = cores)
+    },
+    function(x, par, cores = 1) {
+      dbicop(
+        x,
+        "gaussian",
+        parameters = par,
+        deriv = c("u1", "par1"),
+        cores = cores
+      )
+    },
+    function(x, par, cores = 1) {
+      dbicop(
+        x,
+        "gaussian",
+        parameters = par,
+        log = TRUE,
+        deriv = "par1",
+        cores = cores
+      )
+    },
+    function(x, par, cores = 1) {
+      dbicop(
+        x,
+        "gaussian",
+        parameters = par,
+        log = TRUE,
+        deriv = c("par1", "par1"),
+        cores = cores
+      )
+    },
+    function(x, par, cores = 1) {
+      hbicop(
+        x,
+        1,
+        "gaussian",
+        parameters = par,
+        deriv = "par1",
+        cores = cores
+      )
+    },
+    function(x, par, cores = 1) {
+      hbicop(
+        x,
+        1,
+        "gaussian",
+        parameters = par,
+        deriv = c("u1", "par1"),
+        cores = cores
+      )
+    },
+    function(x, par, cores = 1) {
+      hbicop(
+        x,
+        2,
+        "gaussian",
+        parameters = par,
+        deriv = "par1",
+        cores = cores
+      )
+    },
+    function(x, par, cores = 1) {
+      hbicop(
+        x,
+        2,
+        "gaussian",
+        parameters = par,
+        deriv = c("u2", "par1"),
+        cores = cores
+      )
+    }
+  )
+
+  for (evaluate in evaluators) {
+    expected <- vapply(seq_len(nrow(u)), function(i) {
+      evaluate(u[i, ], parameters[i, 1])
+    }, numeric(1))
+    expect_equal(evaluate(u, parameters, cores = 2), expected)
+  }
+  expect_equal(
+    dbicop(u, "gaussian", parameters = parameters, cores = 2),
+    dbicop(u, "gaussian", parameters = parameters)
+  )
+  expect_equal(
+    hbicop(u, 1, "gaussian", parameters = parameters, inverse = TRUE, cores = 2),
+    hbicop(u, 1, "gaussian", parameters = parameters, inverse = TRUE)
+  )
+})
+
+test_that("function derivative safeguards are enforced", {
+  u <- matrix(c(0.2, 0.3, 0.7, 0.8), ncol = 2)
+  cop <- bicop_dist("gaussian", parameters = 0.4)
+
+  expect_error(dbicop(u, cop, deriv = 1), "character vector")
+  expect_error(dbicop(u, cop, deriv = character()), "length one or two")
+  expect_error(
+    dbicop(u, cop, deriv = c("u1", "u2", "par1")),
+    "length one or two"
+  )
+  expect_error(dbicop(u, cop, deriv = NA_character_), "character vector")
+  expect_error(dbicop(u, cop, deriv = "u3"), "components of 'deriv'")
+  expect_error(dbicop(u, cop, deriv = "par0"), "components of 'deriv'")
+  expect_error(dbicop(u, cop, deriv = "par2"), "parameter")
+  expect_error(dbicop(u, cop, deriv = "u1", cores = 0), "not greater than 0")
+  expect_error(
+    hbicop(u, 1, cop, inverse = TRUE, deriv = "u1"),
+    "inverse h-functions"
+  )
+  expect_error(dbicop(u, bicop_dist("tll"), deriv = "u1"), "not implemented")
+  expect_error(
+    dbicop(
+      cbind(u, u[, 1] - 0.01),
+      "gaussian",
+      parameters = 0.4,
+      var_types = c("d", "c"),
+      deriv = "u1"
+    ),
+    "continuous variable types"
+  )
+  expect_error(
+    hbicop(
+      u,
+      1,
+      "gaussian",
+      parameters = matrix(c(0.2, 0.3, 0.4), ncol = 1),
+      deriv = "par1"
+    ),
+    "one row per row of u"
+  )
+  expect_error(
+    rvinecopulib:::bicop_deriv_cpp(u, cop, "pdf", "u1", 3, 1),
+    "order must be one or two"
+  )
+  expect_error(
+    rvinecopulib:::bicop_deriv_cpp(u, cop, "unknown", "u1", 1, 1),
+    "unknown derivative target"
+  )
+})

--- a/tests/testthat/test_bicop_dist.R
+++ b/tests/testthat/test_bicop_dist.R
@@ -635,9 +635,13 @@ test_that("function derivatives support observation-specific parameters", {
   )
 
   for (evaluate in evaluators) {
-    expected <- vapply(seq_len(nrow(u)), function(i) {
-      evaluate(u[i, ], parameters[i, 1])
-    }, numeric(1))
+    expected <- vapply(
+      seq_len(nrow(u)),
+      function(i) {
+        evaluate(u[i, ], parameters[i, 1])
+      },
+      numeric(1)
+    )
     expect_equal(evaluate(u, parameters, cores = 2), expected)
   }
   expect_equal(
@@ -645,7 +649,14 @@ test_that("function derivatives support observation-specific parameters", {
     dbicop(u, "gaussian", parameters = parameters)
   )
   expect_equal(
-    hbicop(u, 1, "gaussian", parameters = parameters, inverse = TRUE, cores = 2),
+    hbicop(
+      u,
+      1,
+      "gaussian",
+      parameters = parameters,
+      inverse = TRUE,
+      cores = 2
+    ),
     hbicop(u, 1, "gaussian", parameters = parameters, inverse = TRUE)
   )
 })


### PR DESCRIPTION
## Summary

Expose the backend first- and second-order derivatives of bivariate copula densities, log-densities, and h-functions through the existing R evaluators.

This is stacked on #331 because it uses the vinecopulib 1.0 derivative API and the earlier observation-specific parameter support.

## API decisions

- Add `log = FALSE`, `deriv = NULL`, and `cores = 1` to `dbicop()` after the existing arguments.
- Add `deriv = NULL` and `cores = 1` to `hbicop()` after the existing arguments.
- Keep ordinary evaluation as the default with `deriv = NULL`; `dbicop(log = TRUE)` also returns the log-density.
- Use a length-one selector such as `"u1"` or `"par1"` for first derivatives and a length-two selector such as `c("u1", "par1")` for second derivatives. `"par"` aliases `"par1"`, and mixed derivative order is immaterial.
- Reject derivatives of inverse h-functions explicitly. Derivatives remain limited to continuous parametric copulas, following the backend contract.
- Apply `cores` to observation-specific parameter evaluation, including ordinary density and h-function paths.

## Implementation

A single internal Rcpp dispatcher selects density, log-density, h1, or h2 and the first- or second-order backend method. It preserves fixed and observation-specific parameter paths, while rotations and analytic versus finite-difference evaluation remain backend-controlled. The public selector is normalized and validated in R. Documentation and NEWS are updated.

## Tests

- Full testthat suite: 852 passed, 0 failed, 0 warnings, 0 skipped.
- Tests cover deterministic finite-difference agreement, score/Hessian equivalence, rotations, density/h-function identities, mixed and repeated derivatives, all fixed/vectorized dispatcher paths, multicore parity, and selector/model/input safeguards.
- `R CMD check --no-manual --as-cran` completed with tests and examples passing. Its remaining output is the existing non-portable compiler-flag warning plus offline URL/time notes from the sandbox.