### PR TITLE
Document vine margin type controls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,9 @@ for the complete backend changes.
 
 ### BUG FIXES
 
+* Document the `type` marginal control and include its continuous default in
+  `vine()`'s displayed arguments ([#309](https://github.com/vinecopulib/rvinecopulib/issues/309)).
+
 * Make inverse Rosenblatt transforms thread-safe and custom tree criteria safe
   under multithreaded fitting.
 

--- a/R/vine.R
+++ b/R/vine.R
@@ -13,7 +13,8 @@
 #'   `rvinecopulib:::expand_factors()`.
 #'   * `xmin` numeric vector of length d; see [kde1d::kde1d()].
 #'   * `xmax` numeric vector of length d; see [kde1d::kde1d()].
-#'   * `type` numeric vector of length d; see [kde1d::kde1d()].
+#'   * `type` character vector of length one or d; variable type, with the same
+#'   allowed values as [kde1d::kde1d()]. Defaults to `"c"` (continuous).
 #'   * `bw` numeric vector of length d; see [kde1d::kde1d()].
 #'   * `deg` numeric vector of length one or d; [kde1d::kde1d()].
 #' @param copula_controls a list with arguments to be passed to [vinecop()].
@@ -96,6 +97,7 @@ vine <- function(
     mult = NULL,
     xmin = NaN,
     xmax = NaN,
+    type = "c",
     bw = NA,
     deg = 2
   ),

--- a/man/vine.Rd
+++ b/man/vine.Rd
@@ -7,7 +7,8 @@
 \usage{
 vine(
   data,
-  margins_controls = list(mult = NULL, xmin = NaN, xmax = NaN, bw = NA, deg = 2),
+  margins_controls = list(mult = NULL, xmin = NaN, xmax = NaN, type = "c", bw = NA,
+    deg = 2),
   copula_controls = list(family_set = "all", structure = NA, par_method = "mle",
     nonpar_method = "constant", mult = 1, selcrit = "aic", psi0 = 0.9, presel = TRUE,
     allow_rotations = TRUE, trunc_lvl = Inf, tree_crit = "tau", threshold = 0, keep_data
@@ -33,7 +34,8 @@ kernel density estimation are multiplied with \code{mult}. Defaults to
 \code{rvinecopulib:::expand_factors()}.
 \item \code{xmin} numeric vector of length d; see \code{\link[kde1d:kde1d]{kde1d::kde1d()}}.
 \item \code{xmax} numeric vector of length d; see \code{\link[kde1d:kde1d]{kde1d::kde1d()}}.
-\item \code{type} numeric vector of length d; see \code{\link[kde1d:kde1d]{kde1d::kde1d()}}.
+\item \code{type} character vector of length one or d; variable type, with the same
+allowed values as \code{\link[kde1d:kde1d]{kde1d::kde1d()}}. Defaults to \code{"c"} (continuous).
 \item \code{bw} numeric vector of length d; see \code{\link[kde1d:kde1d]{kde1d::kde1d()}}.
 \item \code{deg} numeric vector of length one or d; \code{\link[kde1d:kde1d]{kde1d::kde1d()}}.
 }}

--- a/tests/testthat/test_vine.R
+++ b/tests/testthat/test_vine.R
@@ -85,6 +85,9 @@ test_that("conditioning-aware selection is passed to the copula fit", {
 })
 
 test_that("margins_controls works", {
+  default_controls <- eval(formals(vine)$margins_controls)
+  expect_identical(default_controls$type, "c")
+
   fit_mult <- vine(u, margins_controls = list(mult = 2))
   expect_eql(
     sapply(fit_mult$margins, "[[", "mult"),


### PR DESCRIPTION
## Summary

- expose type = "c" in the vine() margin-control defaults
- correct the type documentation and generated help
- add regression coverage and a release-note entry

## Testing

- focused vine tests
- Rd conversion
- git diff whitespace validation

Addresses #309.