### PR TITLE
Overhaul package documentation

### DIFF
--- a/R/bicop.R
+++ b/R/bicop.R
@@ -11,7 +11,7 @@
 #'   additional options.
 #' @param par_method the estimation method for parametric models, either `"mle"`
 #'   for maximum likelihood or `"itau"` for inversion of Kendall's tau (only
-#'   available for one-parameter families and `"t"`.
+#'   available for one-parameter families and `"t"`).
 #' @param nonpar_method the estimation method for nonparametric models, either
 #'   `"constant"` for the standard transformation estimator, or
 #'   `"linear"`/`"quadratic"` for the local-likelihood approximations of order
@@ -70,7 +70,7 @@
 #' * `"twopar"` contains the parametric families with two parameters,
 #' (`"t"`, `"bb1"`, `"bb6"`, `"bb7"`, and `"bb8"`),
 #'
-#' * `"threepar"` contains the paramtric families with three parameters,
+#' * `"threepar"` contains the parametric families with three parameters,
 #' (`"tawn"`),
 #'
 #' * `"elliptical"` contains the elliptical families,

--- a/R/bicop_methods.R
+++ b/R/bicop_methods.R
@@ -345,7 +345,7 @@ ktau_to_par <- function(family, tau) {
 #' @examples
 #' # Simulate and fit a bivariate copula model
 #' u <- rbicop(500, "gauss", 0, 0.5)
-#' fit <- bicop(u, family = "par", keep_data = TRUE)
+#' fit <- bicop(u, family_set = "par", keep_data = TRUE)
 #'
 #' # Predictions
 #' all.equal(predict(fit, u, "hfunc1"), fitted(fit, "hfunc1"),

--- a/R/rvinecopulib.R
+++ b/R/rvinecopulib.R
@@ -1,16 +1,47 @@
 #' High Performance Algorithms for Vine Copula Modeling
 #'
-#' Provides an interface to 'vinecopulib', a C++ library for vine copula
-#' modeling based on 'Boost' and 'Eigen'. The 'rvinecopulib' package implements
-#' the core features of the popular 'VineCopula' package, in particular
-#' inference algorithms for both vine copula and bivariate copula models.
-#' Advantages over 'VineCopula' are a sleeker and more modern API, improved
-#' performances, especially in high dimensions, nonparametric and
-#' multi-parameter families. The 'rvinecopulib' package includes 'vinecopulib'
-#' as header-only C++ library (currently version 0.6.2). Thus users do not need
-#' to install 'vinecopulib' itself in order to use 'rvinecopulib'. Since their
-#' initial releases, 'vinecopulib' is licensed under the MIT License, and
-#' 'rvinecopulib' is licensed under the GNU GPL version 3.
+#' rvinecopulib provides high-performance tools for constructing, fitting,
+#' selecting, simulating, and visualizing bivariate and vine copula models. It
+#' also fits complete multivariate distributions by combining marginal models
+#' with a vine copula. Continuous, integer-valued discrete, mixed, and
+#' zero-inflated variables are supported.
+#'
+#' The package is the R interface to the header-only 'vinecopulib' C++ library,
+#' which is bundled with rvinecopulib. Users do not need to install the C++
+#' library separately. 'vinecopulib' is licensed under the MIT License and
+#' rvinecopulib under the GNU GPL version 3.
+#'
+#' @section Main capabilities:
+#' rvinecopulib provides:
+#' \itemize{
+#'   \item parametric, nonparametric, rotated, and extreme-value pair copulas;
+#'   \item automatic pair-copula family, vine structure, truncation, and
+#'     threshold selection;
+#'   \item complete multivariate distributions with nonparametric,
+#'     parametric, or custom margins;
+#'   \item continuous, integer-valued discrete, mixed, and zero-inflated data;
+#'   \item observation weights and parallel fitting;
+#'   \item conditional simulation and Rosenblatt transforms;
+#'   \item likelihood scores, Hessians, and observation-specific parameters;
+#'   \item custom marginal families and custom tree-selection criteria.
+#' }
+#'
+#' @section Modeling interfaces:
+#' The framework is exposed at three levels. [vine()] models observations on
+#' their original scale by fitting the marginal distributions and dependence
+#' model together. [vinecop()] models uniform pseudo-observations when only the
+#' dependence model is required. [bicop()] provides the corresponding
+#' two-variable workflow.
+#'
+#' The constructors [vine_dist()], [vinecop_dist()], and [bicop_dist()] create
+#' models from explicitly specified components.
+#'
+#' @section Learning more:
+#' Start with `vignette("getting-started")`. Dedicated articles cover
+#' bivariate copulas, vine structures and selection, marginal models,
+#' discrete data, conditional simulation, and likelihood derivatives. The
+#' [package website](https://vinecopulib.github.io/rvinecopulib/) contains the
+#' rendered articles and complete function reference.
 #'
 #' @name rvinecopulib
 #' @docType package
@@ -22,40 +53,21 @@
 #' @keywords package
 #'
 #' @examples
-#' ## bicop_dist objects
-#' bicop_dist("gaussian", 0, 0.5)
-#' str(bicop_dist("gauss", 0, 0.5))
-#' bicop <- bicop_dist("clayton", 90, 3)
-#'
-#' ## bicop objects
-#' u <- rbicop(500, "gauss", 0, 0.5)
-#' fit1 <- bicop(u, family = "par")
-#' fit1
-#'
-#' ## vinecop_dist objects
-#' ## specify pair-copulas
-#' bicop <- bicop_dist("bb1", 90, c(3, 2))
-#' pcs <- list(
-#'   list(bicop, bicop), # pair-copulas in first tree
-#'   list(bicop) # pair-copulas in second tree
+#' ## complete distribution on the original data scale
+#' x <- data.frame(a = rnorm(50), b = rexp(50), n = rpois(50, 2))
+#' fit <- vine(
+#'   x,
+#'   var_types = c("c", "c", "d"),
+#'   copula_controls = list(family_set = "onepar")
 #' )
-#' ## specify R-vine matrix
-#' mat <- matrix(c(1, 2, 3, 1, 2, 0, 1, 0, 0), 3, 3)
-#' ## build the vinecop_dist object
-#' vc <- vinecop_dist(pcs, mat)
-#' summary(vc)
+#' rvine(3, fit)
 #'
-#' ## vinecop objects
-#' u <- sapply(1:3, function(i) runif(50))
-#' vc <- vinecop(u, family = "par")
-#' summary(vc)
+#' ## dependence model on the copula scale
+#' u <- pseudo_obs(as.matrix(USArrests))
+#' copula_fit <- vinecop(u, family_set = "onepar")
+#' summary(copula_fit)
 #'
-#' ## vine_dist objects
-#' vc <- vine_dist(list(stats_margin("norm")), pcs, mat)
-#' summary(vc)
-#'
-#' ## vine objects
-#' x <- sapply(1:3, function(i) rnorm(50))
-#' vc <- vine(x, copula_controls = list(family_set = "par"))
-#' summary(vc)
+#' ## bivariate model
+#' uv <- rbicop(100, "gaussian", 0, 0.5)
+#' bicop(uv, family_set = "par")
 "_PACKAGE"

--- a/R/vinecop.R
+++ b/R/vinecop.R
@@ -47,7 +47,7 @@
 #'   `"random_unweighted"`) during the tree-wise structure selection.
 #'   `"mst_prim"` and `"mst_kruskal"` use Prim's and Kruskal's algorithms
 #'   respectively to select the maximum spanning tree, maximizing
-#'   the sum of the edge weights (i.e., `tree_criterion`).
+#'   the sum of the edge weights (i.e., `tree_crit`).
 #'   `"random_weighted"` and `"random_unweighted"` use Wilson's
 #'   algorithm to generate a random spanning tree, either with probability
 #'   proportional to the product of the edge weights (weighted) or
@@ -87,13 +87,13 @@
 #' financial returns.* Computational Statistics & Data Analysis, 59 (1),
 #' 52-69.
 #' The dependence measure used to select trees (default: Kendall's tau) is
-#' corrected for ties and can be changed using the `tree_criterion`
+#' corrected for ties and can be changed using the `tree_crit`
 #' argument, which can be set to `"tau"`, `"rho"` or `"hoeffd"`.
-#' Both Prim's (default: `"mst_prim"`) and Kruskal's ()`"mst_kruskal"`)
+#' Both Prim's (default: `"mst_prim"`) and Kruskal's (`"mst_kruskal"`)
 #' algorithms are available through `tree_algorithm` to set the
 #' maximum spanning tree selection algorithm.
 #' An alternative to the maximum spanning tree selection is to use random
-#' spanning trees, which can be selected using `controls.tree_algorithm` and
+#' spanning trees, which can be selected using `tree_algorithm` and
 #' come in two flavors, both using Wilson's algorithm loop erased random walks:
 #'
 #'   - "random_weighted"` generates a random spanning tree with probability
@@ -144,19 +144,24 @@
 #' plot(fit)
 #' contour(fit)
 #'
-#' ## select by log-likelihood criterion from one-paramter families
+#' ## select by BIC from one-parameter families
 #' fit <- vinecop(u, family_set = "onepar", selcrit = "bic")
 #' summary(fit)
 #'
 #' ## 1-truncated, Gaussian D-vine
-#' fit <- vinecop(u, structure = dvine_structure(1:5), family = "gauss", trunc_lvl = 1)
+#' fit <- vinecop(
+#'   u,
+#'   structure = dvine_structure(1:5),
+#'   family_set = "gauss",
+#'   trunc_lvl = 1
+#' )
 #' plot(fit)
 #' contour(fit)
 #'
 #' ## Partial structure selection with only first tree specified
 #' structure <- rvine_structure(order = 1:5, list(rep(5, 4)))
 #' structure
-#' fit <- vinecop(u, structure = structure, family = "gauss")
+#' fit <- vinecop(u, structure = structure, family_set = "gauss")
 #' plot(fit)
 #'
 #' ## Model for discrete data

--- a/R/vinecop_methods.R
+++ b/R/vinecop_methods.R
@@ -75,7 +75,7 @@
 #' u <- pseudo_obs(x)
 #'
 #' ## fit a model
-#' vc <- vinecop(u, family = "clayton")
+#' vc <- vinecop(u, family_set = "clayton")
 #'
 #' # simulate from the model
 #' u <- rvinecop(100, vc)
@@ -107,7 +107,11 @@
 #' pairs(rvinecop(200, vc))
 #'
 #' ## Conditional simulation
-#' vc_cond <- vinecop(u, family = "gaussian", conditioning_set = c(2, 4))
+#' vc_cond <- vinecop(
+#'   u,
+#'   family_set = "gaussian",
+#'   conditioning_set = c(2, 4)
+#' )
 #' u_cond <- c(0.25, 0.75)
 #' uc <- rvinecop(
 #'   100,
@@ -406,7 +410,7 @@ summary.vinecop_dist <- function(
 #' @rdname predict_vinecop
 #' @examples
 #' u <- sapply(1:5, function(i) runif(50))
-#' fit <- vinecop(u, family = "par", keep_data = TRUE)
+#' fit <- vinecop(u, family_set = "par", keep_data = TRUE)
 #' all.equal(predict(fit, u), fitted(fit), check.environment = FALSE)
 predict.vinecop <- function(
   object,
@@ -492,7 +496,7 @@ logLik.vinecop <- function(object, ...) {
 #' @export mBICV
 #' @examples
 #' u <- sapply(1:5, function(i) runif(50))
-#' fit <- vinecop(u, family = "par", keep_data = TRUE)
+#' fit <- vinecop(u, family_set = "par", keep_data = TRUE)
 #' mBICV(fit, 0.9) # with a 0.9 prior probability of a non-independence copula
 #' mBICV(fit, 0.1) # with a 0.1 prior probability of a non-independence copula
 mBICV <- function(object, psi0 = 0.9, newdata = NULL) {

--- a/R/vinecop_plot.R
+++ b/R/vinecop_plot.R
@@ -43,7 +43,7 @@
 #' @examples
 #' # set up vine copula model
 #' u <- matrix(runif(20 * 10), 20, 10)
-#' vc <- vinecop(u, family = "indep")
+#' vc <- vinecop(u, family_set = "indep")
 #'
 #' # plot
 #' plot(vc, tree = c(1, 2))

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,34 +1,39 @@
+---
+output:
+  github_document:
+    html_preview: false
+---
 
 <!-- README.md is generated from README.Rmd. Please edit that file. -->
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>", results = "hide")
+devtools::load_all(quiet = TRUE)
+set.seed(1)
+```
 
 # rvinecopulib
 
 [![R-CMD-check](https://github.com/vinecopulib/rvinecopulib/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/vinecopulib/rvinecopulib/actions/workflows/R-CMD-check.yaml)
-[![Coverage
-Status](https://img.shields.io/codecov/c/github/vinecopulib/rvinecopulib/main.svg)](https://app.codecov.io/github/vinecopulib/rvinecopulib?branch=main)
-[![CRAN
-version](https://www.r-pkg.org/badges/version/rvinecopulib)](https://cran.r-project.org/package=rvinecopulib)
-[![CRAN
-downloads](https://cranlogs.r-pkg.org/badges/rvinecopulib)](https://cran.r-project.org/package=rvinecopulib)
+[![Coverage Status](https://img.shields.io/codecov/c/github/vinecopulib/rvinecopulib/main.svg)](https://app.codecov.io/github/vinecopulib/rvinecopulib?branch=main)
+[![CRAN version](https://www.r-pkg.org/badges/version/rvinecopulib)](https://cran.r-project.org/package=rvinecopulib)
+[![CRAN downloads](https://cranlogs.r-pkg.org/badges/rvinecopulib)](https://cran.r-project.org/package=rvinecopulib)
 
-rvinecopulib provides high-performance tools for bivariate and vine
-copula models. It covers model construction, estimation and selection,
-simulation, prediction, visualization, discrete and mixed data, and full
-multivariate distributions with fitted margins. The package is the R
-interface to the
+rvinecopulib provides high-performance tools for bivariate and vine copula
+models. It covers model construction, estimation and selection, simulation,
+prediction, visualization, discrete and mixed data, and full multivariate
+distributions with fitted margins. The package is the R interface to the
 [vinecopulib](https://github.com/vinecopulib/vinecopulib) C++ library.
 
 ## Main capabilities
 
 - fit, select, evaluate, and simulate [bivariate copula
   models](https://vinecopulib.github.io/rvinecopulib/articles/bivariate-copulas.html),
-  including parametric, nonparametric, rotated, and extreme-value
-  families;
+  including parametric, nonparametric, rotated, and extreme-value families;
 - fit and select high-dimensional [vine copula models and
   structures](https://vinecopulib.github.io/rvinecopulib/articles/vine-copula-models.html),
   with automatic family, structure, truncation, and threshold selection;
-- combine vine copulas with nonparametric, parametric, or custom
-  [marginal
+- combine vine copulas with nonparametric, parametric, or custom [marginal
   models](https://vinecopulib.github.io/rvinecopulib/articles/marginal-models.html)
   to form complete multivariate distributions;
 - handle continuous, integer-valued discrete, mixed, and [zero-inflated
@@ -39,20 +44,20 @@ interface to the
 - compute likelihood [scores and
   Hessians](https://vinecopulib.github.io/rvinecopulib/articles/likelihood-inference.html)
   and evaluate models with observation-specific parameters;
-- use parallel fitting, custom marginal families, and custom
-  tree-selection criteria in extensible modeling workflows.
+- use parallel fitting, custom marginal families, and custom tree-selection
+  criteria in extensible modeling workflows.
 
 ## Installation
 
 Install the stable release from CRAN:
 
-``` r
+```{r install-cran, eval=FALSE}
 install.packages("rvinecopulib")
 ```
 
 Install the development version from GitHub:
 
-``` r
+```{r install-github, eval=FALSE}
 remotes::install_github("vinecopulib/rvinecopulib")
 ```
 
@@ -60,18 +65,18 @@ remotes::install_github("vinecopulib/rvinecopulib")
 
 rvinecopulib exposes the same modeling framework at three levels:
 
-| Starting point                       | Main function | Model                  |
-|--------------------------------------|---------------|------------------------|
-| Two uniform variables                | `bicop()`     | One bivariate copula   |
-| Uniform pseudo-observations          | `vinecop()`   | Dependence only        |
-| Observations on their original scale | `vine()`      | Margins and dependence |
+| Starting point | Main function | Model |
+|---|---|---|
+| Two uniform variables | `bicop()` | One bivariate copula |
+| Uniform pseudo-observations | `vinecop()` | Dependence only |
+| Observations on their original scale | `vine()` | Margins and dependence |
 
 ### A bivariate copula
 
-`bicop()` fits and selects a copula model for two uniform variables.
-Fixed models can be created with `bicop_dist()`.
+`bicop()` fits and selects a copula model for two uniform variables. Fixed
+models can be created with `bicop_dist()`.
 
-``` r
+```{r bivariate}
 u <- rbicop(200, family = "clayton", rotation = 90, parameters = 2)
 bivariate_fit <- bicop(u, family_set = "par")
 summary(bivariate_fit)
@@ -82,16 +87,16 @@ tail_dep(bivariate_fit)
 
 See the [bivariate-copula
 article](https://vinecopulib.github.io/rvinecopulib/articles/bivariate-copulas.html)
-for implemented families, rotations, h-functions, dependence measures,
-and selection controls.
+for implemented families, rotations, h-functions, dependence measures, and
+selection controls.
 
 ### A vine copula on the copula scale
 
 `pseudo_obs()` converts continuous observations to approximately uniform
-scores. `vinecop()` then selects the vine structure, pair-copula
-families, and parameters.
+scores. `vinecop()` then selects the vine structure, pair-copula families, and
+parameters.
 
-``` r
+```{r vine-copula}
 u <- pseudo_obs(as.matrix(USArrests))
 copula_fit <- vinecop(u, family_set = "onepar")
 summary(copula_fit)
@@ -106,12 +111,11 @@ for structure construction, selection, truncation, and model inspection.
 
 ### A full distribution on the original scale
 
-`vine()` fits one marginal distribution per variable and a vine copula
-to their probability integral transforms. The default margins are
-nonparametric; parametric and custom marginal families are also
-supported.
+`vine()` fits one marginal distribution per variable and a vine copula to
+their probability integral transforms. The default margins are nonparametric;
+parametric and custom marginal families are also supported.
 
-``` r
+```{r full-distribution}
 n <- 150
 latent <- rnorm(n)
 x <- data.frame(
@@ -131,17 +135,16 @@ rvine(5, fit)
 
 See the [marginal-modeling
 article](https://vinecopulib.github.io/rvinecopulib/articles/marginal-models.html)
-for parametric selection, custom families, ordered variables, zero
-inflation, and observation weights. The [getting-started
+for parametric selection, custom families, ordered variables, zero inflation,
+and observation weights. The [getting-started
 article](https://vinecopulib.github.io/rvinecopulib/articles/getting-started.html)
 develops the complete workflow.
 
-The constructors `bicop_dist()`, `vinecop_dist()`, and `vine_dist()`
-create models from components specified directly.
+The constructors `bicop_dist()`, `vinecop_dist()`, and `vine_dist()` create
+models from components specified directly.
 
-The [complete API
-reference](https://vinecopulib.github.io/rvinecopulib/reference/) and
-all articles are available on the [package
+The [complete API reference](https://vinecopulib.github.io/rvinecopulib/reference/)
+and all articles are available on the [package
 website](https://vinecopulib.github.io/rvinecopulib/). Questions and bug
 reports are welcome in the [GitHub issue
 tracker](https://github.com/vinecopulib/rvinecopulib/issues).

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -34,9 +34,14 @@ reference:
   - vine_dist
   - vine_distributions
   - vine_predict_and_fitted
+  - as_margin
   - margin_dist
+  - stats_margin
   - margin_family
+  - kde1d_family
+  - univariateML_family
   - margin_protocol
+  - margin_family_protocol
   - zero_inflated
 - title: Vine copula models
   contents:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,61 @@
 template:
   bootstrap: 5
 url: https://vinecopulib.github.io/rvinecopulib/
+
+navbar:
+  structure:
+    left: [intro, reference, articles, news]
+    right: [search, github]
+  components:
+    articles:
+      text: Articles
+      menu:
+      - text: Marginal models
+        href: articles/marginal-models.html
+
+reference:
+- title: Full distributions and margins
+  contents:
+  - vine
+  - vine_dist
+  - vine_distributions
+  - vine_predict_and_fitted
+  - margin_dist
+  - margin_family
+  - margin_protocol
+  - zero_inflated
+- title: Vine copula models
+  contents:
+  - vinecop
+  - vinecop_dist
+  - vinecop_distributions
+  - vinecop_predict_and_fitted
+  - rosenblatt
+  - truncate_model
+  - mBICV
+- title: Bivariate copula models
+  contents:
+  - bicop
+  - bicop_dist
+  - bicop_distributions
+  - bicop_dependence
+  - bicop_predict_and_fitted
+  - plot.bicop_dist
+  - par_to_ktau
+  - as.bicop
+- title: R-vine structures
+  contents:
+  - rvine_structure
+  - as_rvine_structure
+  - rvine_structure_sim
+  - plot.rvine_structure
+  - getters
+- title: Diagnostics and utilities
+  contents:
+  - pseudo_obs
+  - emp_cdf
+  - pairs_copula_data
+  - plot.vinecop_dist
+- title: Package
+  contents:
+  - rvinecopulib

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -19,6 +19,13 @@ navbar:
       - text: Margins and data types
       - text: Marginal models
         href: articles/marginal-models.html
+      - text: Discrete, mixed, and zero-inflated data
+        href: articles/discrete-data.html
+      - text: Advanced workflows
+      - text: Conditional simulation and Rosenblatt transforms
+        href: articles/conditional-simulation.html
+      - text: Scores, Hessians, and varying parameters
+        href: articles/likelihood-inference.html
 
 reference:
 - title: Full distributions and margins

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -10,6 +10,13 @@ navbar:
     articles:
       text: Articles
       menu:
+      - text: Getting started
+        href: articles/getting-started.html
+      - text: Bivariate copula models
+        href: articles/bivariate-copulas.html
+      - text: Vine copula models and structures
+        href: articles/vine-copula-models.html
+      - text: Margins and data types
       - text: Marginal models
         href: articles/marginal-models.html
 

--- a/man/bicop.Rd
+++ b/man/bicop.Rd
@@ -35,7 +35,7 @@ additional options.}
 
 \item{par_method}{the estimation method for parametric models, either \code{"mle"}
 for maximum likelihood or \code{"itau"} for inversion of Kendall's tau (only
-available for one-parameter families and \code{"t"}.}
+available for one-parameter families and \code{"t"}).}
 
 \item{nonpar_method}{the estimation method for nonparametric models, either
 \code{"constant"} for the standard transformation estimator, or
@@ -114,7 +114,7 @@ following convenience definitions:
 \itemize{
 \item \code{"twopar"} contains the parametric families with two parameters,
 (\code{"t"}, \code{"bb1"}, \code{"bb6"}, \code{"bb7"}, and \code{"bb8"}),
-\item \code{"threepar"} contains the paramtric families with three parameters,
+\item \code{"threepar"} contains the parametric families with three parameters,
 (\code{"tawn"}),
 \item \code{"elliptical"} contains the elliptical families,
 \item \code{"archimedean"} contains the archimedean families,

--- a/man/mBICV.Rd
+++ b/man/mBICV.Rd
@@ -31,7 +31,7 @@ copula models.
 }
 \examples{
 u <- sapply(1:5, function(i) runif(50))
-fit <- vinecop(u, family = "par", keep_data = TRUE)
+fit <- vinecop(u, family_set = "par", keep_data = TRUE)
 mBICV(fit, 0.9) # with a 0.9 prior probability of a non-independence copula
 mBICV(fit, 0.1) # with a 0.1 prior probability of a non-independence copula
 }

--- a/man/plot.vinecop_dist.Rd
+++ b/man/plot.vinecop_dist.Rd
@@ -59,7 +59,7 @@ The \code{plot()} method returns an object that (among other things) contains th
 \examples{
 # set up vine copula model
 u <- matrix(runif(20 * 10), 20, 10)
-vc <- vinecop(u, family = "indep")
+vc <- vinecop(u, family_set = "indep")
 
 # plot
 plot(vc, tree = c(1, 2))

--- a/man/predict_bicop.Rd
+++ b/man/predict_bicop.Rd
@@ -47,7 +47,7 @@ second block.
 \examples{
 # Simulate and fit a bivariate copula model
 u <- rbicop(500, "gauss", 0, 0.5)
-fit <- bicop(u, family = "par", keep_data = TRUE)
+fit <- bicop(u, family_set = "par", keep_data = TRUE)
 
 # Predictions
 all.equal(predict(fit, u, "hfunc1"), fitted(fit, "hfunc1"),

--- a/man/predict_vinecop.Rd
+++ b/man/predict_vinecop.Rd
@@ -50,6 +50,6 @@ second block.
 }
 \examples{
 u <- sapply(1:5, function(i) runif(50))
-fit <- vinecop(u, family = "par", keep_data = TRUE)
+fit <- vinecop(u, family_set = "par", keep_data = TRUE)
 all.equal(predict(fit, u), fitted(fit), check.environment = FALSE)
 }

--- a/man/rvinecopulib.Rd
+++ b/man/rvinecopulib.Rd
@@ -6,55 +6,74 @@
 \alias{rvinecopulib}
 \title{High Performance Algorithms for Vine Copula Modeling}
 \description{
-Provides an interface to 'vinecopulib', a C++ library for vine copula
-modeling based on 'Boost' and 'Eigen'. The 'rvinecopulib' package implements
-the core features of the popular 'VineCopula' package, in particular
-inference algorithms for both vine copula and bivariate copula models.
-Advantages over 'VineCopula' are a sleeker and more modern API, improved
-performances, especially in high dimensions, nonparametric and
-multi-parameter families. The 'rvinecopulib' package includes 'vinecopulib'
-as header-only C++ library (currently version 0.6.2). Thus users do not need
-to install 'vinecopulib' itself in order to use 'rvinecopulib'. Since their
-initial releases, 'vinecopulib' is licensed under the MIT License, and
-'rvinecopulib' is licensed under the GNU GPL version 3.
+rvinecopulib provides high-performance tools for constructing, fitting,
+selecting, simulating, and visualizing bivariate and vine copula models. It
+also fits complete multivariate distributions by combining marginal models
+with a vine copula. Continuous, integer-valued discrete, mixed, and
+zero-inflated variables are supported.
 }
+\details{
+The package is the R interface to the header-only 'vinecopulib' C++ library,
+which is bundled with rvinecopulib. Users do not need to install the C++
+library separately. 'vinecopulib' is licensed under the MIT License and
+rvinecopulib under the GNU GPL version 3.
+}
+\section{Main capabilities}{
+
+rvinecopulib provides:
+\itemize{
+\item parametric, nonparametric, rotated, and extreme-value pair copulas;
+\item automatic pair-copula family, vine structure, truncation, and
+threshold selection;
+\item complete multivariate distributions with nonparametric,
+parametric, or custom margins;
+\item continuous, integer-valued discrete, mixed, and zero-inflated data;
+\item observation weights and parallel fitting;
+\item conditional simulation and Rosenblatt transforms;
+\item likelihood scores, Hessians, and observation-specific parameters;
+\item custom marginal families and custom tree-selection criteria.
+}
+}
+
+\section{Modeling interfaces}{
+
+The framework is exposed at three levels. \code{\link[=vine]{vine()}} models observations on
+their original scale by fitting the marginal distributions and dependence
+model together. \code{\link[=vinecop]{vinecop()}} models uniform pseudo-observations when only the
+dependence model is required. \code{\link[=bicop]{bicop()}} provides the corresponding
+two-variable workflow.
+
+The constructors \code{\link[=vine_dist]{vine_dist()}}, \code{\link[=vinecop_dist]{vinecop_dist()}}, and \code{\link[=bicop_dist]{bicop_dist()}} create
+models from explicitly specified components.
+}
+
+\section{Learning more}{
+
+Start with \code{vignette("getting-started")}. Dedicated articles cover
+bivariate copulas, vine structures and selection, marginal models,
+discrete data, conditional simulation, and likelihood derivatives. The
+\href{https://vinecopulib.github.io/rvinecopulib/}{package website} contains the
+rendered articles and complete function reference.
+}
+
 \examples{
-## bicop_dist objects
-bicop_dist("gaussian", 0, 0.5)
-str(bicop_dist("gauss", 0, 0.5))
-bicop <- bicop_dist("clayton", 90, 3)
-
-## bicop objects
-u <- rbicop(500, "gauss", 0, 0.5)
-fit1 <- bicop(u, family = "par")
-fit1
-
-## vinecop_dist objects
-## specify pair-copulas
-bicop <- bicop_dist("bb1", 90, c(3, 2))
-pcs <- list(
-  list(bicop, bicop), # pair-copulas in first tree
-  list(bicop) # pair-copulas in second tree
+## complete distribution on the original data scale
+x <- data.frame(a = rnorm(50), b = rexp(50), n = rpois(50, 2))
+fit <- vine(
+  x,
+  var_types = c("c", "c", "d"),
+  copula_controls = list(family_set = "onepar")
 )
-## specify R-vine matrix
-mat <- matrix(c(1, 2, 3, 1, 2, 0, 1, 0, 0), 3, 3)
-## build the vinecop_dist object
-vc <- vinecop_dist(pcs, mat)
-summary(vc)
+rvine(3, fit)
 
-## vinecop objects
-u <- sapply(1:3, function(i) runif(50))
-vc <- vinecop(u, family = "par")
-summary(vc)
+## dependence model on the copula scale
+u <- pseudo_obs(as.matrix(USArrests))
+copula_fit <- vinecop(u, family_set = "onepar")
+summary(copula_fit)
 
-## vine_dist objects
-vc <- vine_dist(list(stats_margin("norm")), pcs, mat)
-summary(vc)
-
-## vine objects
-x <- sapply(1:3, function(i) rnorm(50))
-vc <- vine(x, copula_controls = list(family_set = "par"))
-summary(vc)
+## bivariate model
+uv <- rbicop(100, "gaussian", 0, 0.5)
+bicop(uv, family_set = "par")
 }
 \seealso{
 Useful links:

--- a/man/vinecop.Rd
+++ b/man/vinecop.Rd
@@ -50,7 +50,7 @@ selection of the structure.}
 
 \item{par_method}{the estimation method for parametric models, either \code{"mle"}
 for maximum likelihood or \code{"itau"} for inversion of Kendall's tau (only
-available for one-parameter families and \code{"t"}.}
+available for one-parameter families and \code{"t"}).}
 
 \item{nonpar_method}{the estimation method for nonparametric models, either
 \code{"constant"} for the standard transformation estimator, or
@@ -113,7 +113,7 @@ tree (\code{"mst_prim"}, \code{"mst_kruskal"}, \code{"random_weighted"}, or
 \code{"random_unweighted"}) during the tree-wise structure selection.
 \code{"mst_prim"} and \code{"mst_kruskal"} use Prim's and Kruskal's algorithms
 respectively to select the maximum spanning tree, maximizing
-the sum of the edge weights (i.e., \code{tree_criterion}).
+the sum of the edge weights (i.e., \code{tree_crit}).
 \code{"random_weighted"} and \code{"random_unweighted"} use Wilson's
 algorithm to generate a random spanning tree, either with probability
 proportional to the product of the edge weights (weighted) or
@@ -174,13 +174,13 @@ Dissmann, J. F., E. C. Brechmann, C. Czado, and D. Kurowicka (2013).
 financial returns.} Computational Statistics & Data Analysis, 59 (1),
 52-69.
 The dependence measure used to select trees (default: Kendall's tau) is
-corrected for ties and can be changed using the \code{tree_criterion}
+corrected for ties and can be changed using the \code{tree_crit}
 argument, which can be set to \code{"tau"}, \code{"rho"} or \code{"hoeffd"}.
-Both Prim's (default: \code{"mst_prim"}) and Kruskal's ()\code{"mst_kruskal"})
+Both Prim's (default: \code{"mst_prim"}) and Kruskal's (\code{"mst_kruskal"})
 algorithms are available through \code{tree_algorithm} to set the
 maximum spanning tree selection algorithm.
 An alternative to the maximum spanning tree selection is to use random
-spanning trees, which can be selected using \code{controls.tree_algorithm} and
+spanning trees, which can be selected using \code{tree_algorithm} and
 come in two flavors, both using Wilson's algorithm loop erased random walks:
 \itemize{
 \item "random_weighted"` generates a random spanning tree with probability
@@ -210,19 +210,24 @@ summary(fit)
 plot(fit)
 contour(fit)
 
-## select by log-likelihood criterion from one-paramter families
+## select by BIC from one-parameter families
 fit <- vinecop(u, family_set = "onepar", selcrit = "bic")
 summary(fit)
 
 ## 1-truncated, Gaussian D-vine
-fit <- vinecop(u, structure = dvine_structure(1:5), family = "gauss", trunc_lvl = 1)
+fit <- vinecop(
+  u,
+  structure = dvine_structure(1:5),
+  family_set = "gauss",
+  trunc_lvl = 1
+)
 plot(fit)
 contour(fit)
 
 ## Partial structure selection with only first tree specified
 structure <- rvine_structure(order = 1:5, list(rep(5, 4)))
 structure
-fit <- vinecop(u, structure = structure, family = "gauss")
+fit <- vinecop(u, structure = structure, family_set = "gauss")
 plot(fit)
 
 ## Model for discrete data

--- a/man/vinecop_methods.Rd
+++ b/man/vinecop_methods.Rd
@@ -48,8 +48,6 @@ done in parallel on \code{cores} batches .}
 \item{keep_all}{if \code{TRUE}, \code{dvinecop()} returns additional intermediate
 quantities computed during density evaluation.}
 
-\item{...}{unused.}
-
 \item{parameters}{optional observation-specific parameters for \code{dvinecop()},
 \code{scores()}, and \code{hessian()}. For a model with one parameter, this may be a
 vector with one entry per observation. Otherwise, it must be a matrix with
@@ -57,6 +55,8 @@ one row per observation and one column per model parameter. For vine
 copulas, columns follow the \verb{(tree, edge, parameter)} order of \code{scores()}.
 Parameters are not recycled. Only continuous parametric models are
 supported.}
+
+\item{...}{unused.}
 
 \item{step_wise}{if \code{FALSE}, the score/Hessian is computed for the full
 likelihood; if \code{TRUE}, gradients are computed per pair-copula as in
@@ -129,7 +129,7 @@ x <- rnorm(30) * matrix(1, 30, 5) + 0.5 * matrix(rnorm(30 * 5), 30, 5)
 u <- pseudo_obs(x)
 
 ## fit a model
-vc <- vinecop(u, family = "clayton")
+vc <- vinecop(u, family_set = "clayton")
 
 # simulate from the model
 u <- rvinecop(100, vc)
@@ -161,7 +161,11 @@ pvinecop(u_disc[1:5, ], vc)
 pairs(rvinecop(200, vc))
 
 ## Conditional simulation
-vc_cond <- vinecop(u, family = "gaussian", conditioning_set = c(2, 4))
+vc_cond <- vinecop(
+  u,
+  family_set = "gaussian",
+  conditioning_set = c(2, 4)
+)
 u_cond <- c(0.25, 0.75)
 uc <- rvinecop(
   100,

--- a/vignettes/bivariate-copulas.Rmd
+++ b/vignettes/bivariate-copulas.Rmd
@@ -1,0 +1,203 @@
+---
+title: "Bivariate copula models"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Bivariate copula models}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(201)
+```
+
+Bivariate copulas are the building blocks of vine models. rvinecopulib can
+construct a known model, fit or select one from data, evaluate its distribution
+functions, and summarize its dependence.
+
+## Implemented families
+
+| Type | Family | Identifier | Parameters |
+|---|---|---|---:|
+| Independence | Independence | `"indep"` | 0 |
+| Elliptical | Gaussian | `"gaussian"` | 1 |
+| Elliptical | Student t | `"t"` | 2 |
+| Archimedean | Clayton | `"clayton"` | 1 |
+| Archimedean | Gumbel | `"gumbel"` | 1 |
+| Archimedean | Frank | `"frank"` | 1 |
+| Archimedean | Joe | `"joe"` | 1 |
+| Archimedean | BB1, BB6, BB7, BB8 | lower-case name | 2 |
+| Extreme value | Tawn | `"tawn"` | 3 |
+| Nonparametric | Transformation kernel | `"tll"` | effective count |
+
+Unambiguous partial names such as `"gauss"` and collection aliases such as
+`"par"` are accepted. For reusable code, full names make intent clearer.
+
+## Construct a known model
+
+`bicop_dist()` specifies a family, rotation, parameters, and variable types.
+
+```{r construct}
+cop <- bicop_dist(
+  family = "clayton",
+  rotation = 90,
+  parameters = 2
+)
+cop
+```
+
+Rotations are `0`, `90`, `180`, or `270` degrees. They allow asymmetric
+Archimedean copulas to represent different corners and negative dependence.
+Elliptical, Frank, independence, and nonparametric copulas already cover both
+signs without rotations.
+
+## Evaluate and simulate
+
+The density, CDF, and random generator follow R's `d*`, `p*`, and `r*`
+conventions.
+
+```{r evaluate}
+points <- rbind(c(0.2, 0.7), c(0.8, 0.3))
+dbicop(points, cop)
+pbicop(points, cop)
+rbicop(4, cop)
+```
+
+The same functions also accept family, rotation, and parameters directly:
+
+```{r direct}
+dbicop(points, "gaussian", 0, 0.6)
+```
+
+## Conditional distributions and h-functions
+
+H-functions are the conditional distributions used recursively in vine
+copulas. If `cond_var = 1`, the first input variable is conditioned on and the
+function returns the conditional CDF of the second. With `inverse = TRUE`, it
+returns the corresponding conditional quantile.
+
+```{r h-functions}
+h <- hbicop(points, cond_var = 1, family = cop)
+h
+hbicop(cbind(points[, 1], h), cond_var = 1, family = cop, inverse = TRUE)
+```
+
+This round trip recovers the second column up to numerical precision. The same
+conditional-distribution operations drive vine recursion and simulation.
+
+## Dependence measures
+
+`par_to_ktau()` converts family parameters to Kendall's tau, and
+`ktau_to_par()` provides the inverse for families where tau determines all
+parameters. Model objects expose Kendall's tau through `get_ktau()`.
+
+```{r dependence}
+par_to_ktau("clayton", 90, 2)
+get_ktau(cop)
+blomqvist_beta(cop)
+tail_dep(cop)
+```
+
+`tail_dep()` reports the four corner tail-dependence coefficients. This is
+especially useful for rotated and asymmetric families, where a single
+lower/upper pair is not enough to describe the model.
+
+## Fit and select from data
+
+`bicop()` expects two approximately uniform columns. It fits every requested
+compatible family and selects the best according to `selcrit`.
+
+```{r selection}
+u <- rbicop(300, "gumbel", 180, 2)
+fit <- bicop(
+  u,
+  family_set = c("gaussian", "clayton", "gumbel", "frank"),
+  selcrit = "bic"
+)
+fit
+summary(fit)
+```
+
+Useful family collections include:
+
+- `"all"`, `"parametric"`, and `"nonparametric"`;
+- `"oneparametric"`, `"twoparametric"`, and `"threeparametric"`;
+- `"elliptical"`, `"archimedean"`, `"ev"`, and `"bbs"`;
+- `"itau"`, the families compatible with Kendall's tau inversion.
+
+Partial matching makes shorter forms such as `"onepar"` and `"par"`
+available. Explicit character vectors are preferable when the candidate set is
+part of a scientific specification.
+
+Maximum likelihood is the default for parametric families. Set
+`par_method = "itau"` for Kendall's tau inversion. The transformation-kernel
+model uses `nonpar_method` and `mult` to control the local-likelihood order and
+smoothing.
+
+## Observation weights and missing values
+
+Pass one nonnegative weight per row with `weights`. The backend standardizes
+weights internally. Missing or zero-weight observations do not contribute to a
+pair fit.
+
+```{r weights}
+weights <- seq_len(nrow(u))
+weighted_fit <- bicop(
+  u,
+  family_set = c("gaussian", "gumbel"),
+  weights = weights
+)
+weighted_fit
+```
+
+## Discrete variables
+
+A discrete copula observation needs both `F(x)` and `F(x-)`. For two discrete
+variables, pass four columns: the two CDF values followed by their two left
+limits. Redundant left-limit columns for continuous variables may be omitted.
+
+```{r discrete}
+counts <- cbind(rpois(80, 2), rpois(80, 3))
+u_discrete <- cbind(
+  ppois(counts[, 1], 2),
+  ppois(counts[, 2], 3),
+  ppois(counts[, 1] - 1, 2),
+  ppois(counts[, 2] - 1, 3)
+)
+fit_discrete <- bicop(
+  u_discrete,
+  var_types = c("d", "d"),
+  family_set = "onepar"
+)
+fit_discrete
+```
+
+The dedicated discrete-data guide covers compact layouts, mixed models, and
+atoms in detail.
+
+## Observation-specific parameters
+
+Evaluation and simulation can use one parameter set per observation without
+constructing many model objects. A one-parameter family accepts a vector;
+multi-parameter families use a matrix with one row per observation.
+
+```{r vectorized}
+rho <- seq(-0.7, 0.7, length.out = nrow(points))
+dbicop(points, "gaussian", 0, parameters = rho)
+rbicop(length(rho), "gaussian", 0, parameters = rho)
+```
+
+This interface is intended for conditional or covariate-dependent copula
+models. Parameters are not recycled, and vectorized evaluation is limited to
+parametric families.
+
+## Related documentation
+
+- [Vine copula models and structures](vine-copula-models.html) shows how
+  bivariate copulas are assembled into a high-dimensional model.
+- The [`bicop()` reference](../reference/bicop.html) lists all fitting
+  controls; [`bicop_dist()` and its distribution
+  functions](../reference/bicop_dist.html) document construction and
+  evaluation.

--- a/vignettes/bivariate-copulas.Rmd
+++ b/vignettes/bivariate-copulas.Rmd
@@ -85,7 +85,9 @@ hbicop(cbind(points[, 1], h), cond_var = 1, family = cop, inverse = TRUE)
 ```
 
 This round trip recovers the second column up to numerical precision. The same
-conditional-distribution operations drive vine recursion and simulation.
+conditional-distribution operations drive vine recursion and simulation; see
+[Conditional simulation and Rosenblatt
+transforms](conditional-simulation.html) for the multivariate workflow.
 
 ## Dependence measures
 
@@ -174,8 +176,8 @@ fit_discrete <- bicop(
 fit_discrete
 ```
 
-The dedicated discrete-data guide covers compact layouts, mixed models, and
-atoms in detail.
+The [discrete-data guide](discrete-data.html) derives the likelihood
+contribution and covers compact layouts, mixed models, and atoms in detail.
 
 ## Observation-specific parameters
 
@@ -197,6 +199,8 @@ parametric families.
 
 - [Vine copula models and structures](vine-copula-models.html) shows how
   bivariate copulas are assembled into a high-dimensional model.
+- [Scores, Hessians, and varying parameters](likelihood-inference.html)
+  documents likelihood derivatives and parameter ordering.
 - The [`bicop()` reference](../reference/bicop.html) lists all fitting
   controls; [`bicop_dist()` and its distribution
   functions](../reference/bicop_dist.html) document construction and

--- a/vignettes/conditional-simulation.Rmd
+++ b/vignettes/conditional-simulation.Rmd
@@ -1,0 +1,200 @@
+---
+title: "Conditional simulation and Rosenblatt transforms"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Conditional simulation and Rosenblatt transforms}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(501)
+```
+
+A vine is simulated along an order. Variables to condition on must form the
+tail of an admissible sampling order. rvinecopulib can enforce this during
+structure selection or transiently reorient a compatible fitted model during
+simulation.
+
+## Select a conditioning-aware structure
+
+Pass variable indices or names through `conditioning_set` when fitting a
+copula. The selected structure places those variables at the end of its order.
+
+```{r select-copula}
+n <- 180
+z <- rnorm(n)
+x <- cbind(
+  response1 = z + rnorm(n),
+  response2 = -0.5 * z + rnorm(n),
+  driver1 = z + rnorm(n, sd = 0.5),
+  driver2 = 0.4 * z + rnorm(n)
+)
+u <- pseudo_obs(x)
+
+fit <- vinecop(
+  u,
+  family_set = "onepar",
+  conditioning_set = c("driver1", "driver2")
+)
+get_structure(fit)
+```
+
+Conditioning-aware selection requires a full, non-truncated vine and an MST
+tree algorithm (`"mst_prim"` or `"mst_kruskal"`). Random tree algorithms do
+not guarantee the required order.
+
+## Simulate conditionally on the copula scale
+
+`u_cond` contains one value per conditioning variable. A vector or one-row
+matrix is repeated for all simulations; an `n`-row matrix specifies different
+conditions for every output row.
+
+```{r conditional-copula}
+condition <- c(0.25, 0.8)
+draws <- rvinecop(
+  100,
+  fit,
+  u_cond = condition,
+  conditioning_set = c("driver1", "driver2")
+)
+stopifnot(
+  isTRUE(all.equal(draws[, "driver1"], rep(condition[1], 100))),
+  isTRUE(all.equal(draws[, "driver2"], rep(condition[2], 100)))
+)
+head(draws)
+```
+
+When `conditioning_set` is omitted, the columns of `u_cond` refer to the last
+variables in the model's current order.
+
+```{r row-specific-conditions}
+conditions <- cbind(
+  driver1 = seq(0.1, 0.9, length.out = 5),
+  driver2 = rep(0.5, 5)
+)
+row_draws <- rvinecop(
+  5,
+  fit,
+  u_cond = conditions,
+  conditioning_set = c("driver1", "driver2")
+)
+stopifnot(isTRUE(all.equal(row_draws[, 3:4], conditions)))
+```
+
+## Condition on the original data scale
+
+`vine()` exposes the same structure control through `copula_controls`.
+`rvine()` accepts `x_cond` on the original scale and uses the fitted margins to
+compute all necessary CDF values and left limits.
+
+```{r conditional-original-scale}
+full_fit <- vine(
+  as.data.frame(x),
+  margins_controls = list(family_set = "kde1d"),
+  copula_controls = list(
+    family_set = "onepar",
+    conditioning_set = c("driver1", "driver2")
+  )
+)
+
+original_condition <- data.frame(driver1 = -0.5, driver2 = 1.25)
+original_draws <- rvine(
+  6,
+  full_fit,
+  x_cond = original_condition,
+  conditioning_set = c("driver1", "driver2")
+)
+stopifnot(
+  isTRUE(all.equal(original_draws[, "driver1"], rep(-0.5, 6))),
+  isTRUE(all.equal(original_draws[, "driver2"], rep(1.25, 6)))
+)
+```
+
+Column names are strongly recommended: they make the mapping explicit and
+protect code from changes in variable order.
+
+## Reorient an existing model transiently
+
+Supplying an explicit `conditioning_set` to `rvinecop()` or `rvine()` asks the
+backend to evaluate an equivalent orientation without modifying the model.
+Only conditioning sets that can form an admissible tail of the fitted
+structure are possible. If a specific set is central to the analysis, request
+it during fitting; selection then guarantees a usable structure.
+
+## Discrete conditioning variables
+
+On the copula scale, a discrete conditioning variable needs its value `F(x)`
+and left limit `F(x-)`. As with model evaluation, `u_cond` accepts:
+
+- a compact layout with one value column per conditioning variable followed by
+  one left-limit column per discrete variable; or
+- an expanded layout with all value columns followed by all left-limit
+  columns, where a continuous variable's two columns must be equal.
+
+`rvine()` handles this internally from `x_cond`, including ordered and
+zero-inflated margins.
+
+## Rosenblatt transforms
+
+The Rosenblatt transform maps observations from a fitted distribution to
+independent uniforms. For continuous variables in a sampling sequence
+`s1, ..., sd`, its components are
+\[
+Z_j = F_{s_j \mid s_1,\ldots,s_{j-1}}
+\left(X_{s_j}\mid X_{s_1},\ldots,X_{s_{j-1}}\right),
+\qquad j=1,\ldots,d,
+\]
+where the first component is unconditional. If the fitted model is correct,
+the `Z_j` are independent standard uniforms. The inverse transform applies the
+corresponding conditional quantiles recursively and therefore maps independent
+uniforms back to the model.
+
+```{r rosenblatt}
+simulated <- rvinecop(100, fit)
+independent <- rosenblatt(simulated, fit)
+reconstructed <- inverse_rosenblatt(independent, fit)
+max(abs(simulated - reconstructed))
+```
+
+The transform follows the model's sampling order. An explicit
+`conditioning_set` requests an admissible order ending in those variables,
+which is useful when conditional quantiles must follow the same orientation as
+conditional simulation.
+
+```{r conditional-rosenblatt}
+transformed <- rosenblatt(
+  simulated,
+  fit,
+  conditioning_set = c("driver1", "driver2")
+)
+inverse_rosenblatt(
+  transformed,
+  fit,
+  conditioning_set = c("driver1", "driver2")
+)[1:3, ]
+```
+
+For discrete variables, the transform randomizes within the jump interval by
+default. See the [discrete-data guide](discrete-data.html) for the randomized
+formula, deterministic upper endpoints, and required copula layouts.
+
+## Reproducibility
+
+Conditional simulation and randomized discrete transforms use R's
+random-number state. Call `set.seed()` immediately before the operation when a
+reproducible draw is required. The original model object is never mutated by a
+conditional simulation or transform.
+
+## Related documentation
+
+- [Vine copula models and structures](vine-copula-models.html) explains the
+  structure order and selection controls used here.
+- [Marginal models](marginal-models.html) documents the transformation between
+  original observations and the copula scale.
+- The [`rvinecop()` reference](../reference/vinecop_methods.html),
+  [`rvine()` reference](../reference/vine_methods.html), and [Rosenblatt
+  reference](../reference/rosenblatt.html) give complete argument and return
+  value details.

--- a/vignettes/discrete-data.Rmd
+++ b/vignettes/discrete-data.Rmd
@@ -1,0 +1,254 @@
+---
+title: "Discrete, mixed, and zero-inflated data"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Discrete, mixed, and zero-inflated data}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(401)
+```
+
+Copula likelihoods for variables with atoms require two probabilities at every
+observation: the CDF value `F(x)` and its left limit `F(x-)`. For an
+integer-valued variable, `F(x-) = F(x - 1)`. Continuous variables satisfy
+`F(x-) = F(x)`.
+
+The high-level `vine()` interface computes these values from fitted margins.
+The copula-only `bicop()` and `vinecop()` interfaces accept them explicitly.
+
+## Discrete variables on the original scale
+
+All ordinary discrete variables are assumed to have integer support. Declare a
+numeric or integer column through `var_types = "d"`.
+
+```{r integer-data}
+n <- 100
+latent <- rnorm(n)
+x <- data.frame(
+  value = latent + rnorm(n),
+  count = rpois(n, exp(0.5 + 0.3 * latent))
+)
+
+fit <- vine(
+  x,
+  var_types = c("c", "d"),
+  copula_controls = list(family_set = "onepar")
+)
+summary(fit)$margins
+dvine(x[1:5, ], fit)
+```
+
+Explicitly discrete columns are checked for finite integer-valued observations.
+This catches accidental declarations of rounded-looking continuous data.
+
+## Ordered factors
+
+Ordered factors are discrete variables whose levels are mapped internally to
+the integer support `0, 1, ...`. Their class and levels are restored after
+simulation.
+
+```{r ordered-data}
+survey <- data.frame(
+  rating = ordered(
+    sample(c("low", "middle", "high"), n, replace = TRUE),
+    levels = c("low", "middle", "high")
+  ),
+  score = rnorm(n)
+)
+
+ordered_fit <- vine(
+  survey,
+  copula_controls = list(family_set = "indep")
+)
+ordered_draws <- rvine(5, ordered_fit)
+str(ordered_draws)
+```
+
+No `var_types` entry is needed because `ordered()` carries the declaration in
+the column class.
+
+## Zero-inflated variables
+
+`zero_inflated()` marks a continuous variable with an atom at zero. It behaves
+like a numeric vector in a data frame and survives ordinary subsetting.
+
+```{r zero-inflated}
+amount <- zero_inflated(c(rep(0, 25), rexp(75)))
+zi_data <- data.frame(amount = amount, score = rnorm(100))
+inherits(zi_data$amount, "zero_inflated")
+
+zi_fit <- vine(
+  zi_data,
+  copula_controls = list(family_set = "indep")
+)
+zi_fit$margins_controls$type
+```
+
+The atom is always located at zero. A custom zero-inflated margin must return
+the atom probability from `dmargin(0, margin)`. rvinecopulib then computes the
+left limit as
+
+```
+pmargin(0, margin) - dmargin(0, margin)
+```
+
+and uses the ordinary CDF away from zero. Alternatively, declare the type with
+`var_types = "zi"`.
+
+## Copula-scale data layouts
+
+Let `d` be the dimension and `k` the number of discrete variables. Copula
+methods accept two layouts:
+
+- **expanded:** `2d` columns, with all `F(x)` columns followed by all `F(x-)`
+  columns;
+- **compact:** `d + k` columns, with the `F(x)` block followed only by
+  left-limit columns for discrete variables, in variable order.
+
+Consider a three-dimensional model with discrete variables 1 and 3.
+
+```{r layouts}
+n <- 80
+raw <- data.frame(
+  first = rpois(n, 2),
+  middle = rnorm(n),
+  last = rpois(n, 4)
+)
+
+values <- cbind(
+  ppois(raw$first, 2),
+  pnorm(raw$middle),
+  ppois(raw$last, 4)
+)
+left_discrete <- cbind(
+  ppois(raw$first - 1, 2),
+  ppois(raw$last - 1, 4)
+)
+compact <- cbind(values, left_discrete)
+
+left_all <- cbind(
+  ppois(raw$first - 1, 2),
+  pnorm(raw$middle),
+  ppois(raw$last - 1, 4)
+)
+expanded <- cbind(values, left_all)
+
+copula_fit <- vinecop(
+  compact,
+  var_types = c("d", "c", "d"),
+  family_set = "indep"
+)
+stopifnot(isTRUE(all.equal(
+  dvinecop(compact, copula_fit),
+  dvinecop(expanded, copula_fit)
+)))
+```
+
+For a mixed bivariate model, this means three columns: the two CDF values and
+the left limit of the discrete variable. Fully discrete bivariate models need
+four columns.
+
+## What the density means
+
+`dbicop()` and `dvinecop()` return the copula density contribution defined as
+the joint density or mass divided by the marginal densities or masses. This
+definition is consistent across continuous, discrete, and mixed models.
+
+For a bivariate model, write
+\[
+u_j = F_j(x_j), \qquad u_j^- = F_j(x_j^-), \qquad
+\Delta_j = u_j - u_j^-.
+\]
+If both variables are discrete, the copula contribution is the rectangle
+probability divided by the two marginal masses:
+\[
+c^*(u_1,u_2) =
+\frac{C(u_1,u_2)-C(u_1^-,u_2)-C(u_1,u_2^-)+C(u_1^-,u_2^-)}
+     {\Delta_1\Delta_2}.
+\]
+If only the first variable is discrete, the corresponding mixed contribution
+is
+\[
+c^*(u_1,u_2) =
+\frac{\partial_2 C(u_1,u_2)-\partial_2 C(u_1^-,u_2)}{\Delta_1}.
+\]
+The continuous density `c(u1, u2)` is recovered when both jump widths vanish.
+Vine likelihoods apply these continuous, mixed, or rectangle contributions
+edge by edge to the appropriate conditional CDF values.
+
+`dvine()` multiplies that contribution by the fitted marginal densities or
+masses and therefore returns the full joint density or probability mass on the
+original scale. In general,
+\[
+f_X(x) = c^*(u,u^-)\prod_{j=1}^d f_j(x_j),
+\]
+where each `f_j` denotes a density or a probability mass as appropriate.
+
+## Simulation
+
+`rvinecop()` always returns one uniform-scale value per variable. It does not
+invent a marginal distribution for a discrete copula variable. Use `rvine()`
+when simulated values should be returned on the original scale with their
+integer, ordered, or zero-inflated margins.
+
+```{r simulation}
+copula_draws <- rvinecop(4, copula_fit)
+dim(copula_draws)
+
+original_draws <- rvine(4, ordered_fit)
+is.ordered(original_draws$rating)
+```
+
+## Rosenblatt transforms with atoms
+
+For an atom, the Rosenblatt transform is an interval rather than a single
+value. By default, `rosenblatt()` randomizes uniformly within that interval so
+the transformed variable is uniform under a correct model. Set
+`randomize_discrete = FALSE` to return the deterministic upper endpoint.
+
+More precisely, if `G_j(· | x_<j)` is the relevant conditional CDF and
+`V_j` is an independent standard uniform variable, the randomized component is
+\[
+Z_j = G_j(x_j^- \mid x_{<j})
+    + V_j\{G_j(x_j \mid x_{<j})-G_j(x_j^- \mid x_{<j})\}.
+\]
+The non-randomized version returns the upper endpoint `G_j(x_j | x_<j)`.
+
+```{r discrete-rosenblatt}
+set.seed(402)
+randomized <- rosenblatt(compact, copula_fit)
+upper_endpoint <- rosenblatt(
+  compact,
+  copula_fit,
+  randomize_discrete = FALSE
+)
+head(randomized)
+head(upper_endpoint)
+```
+
+The randomization uses R's random-number state and is reproducible with
+`set.seed()`.
+
+## Missing observations
+
+Copula fitting discards incomplete observations pair by pair, retaining the
+maximum information available for each edge. Margin implementations decide how
+to handle missing values during marginal fitting; built-in KDE margins support
+the package's established missing-data workflow. Custom `margin_family()`
+fitters should either handle missing values or fail with a useful message.
+
+## Related documentation
+
+- [Marginal models](marginal-models.html) documents how `vine()` fits and
+  evaluates integer, ordered, and zero-inflated margins.
+- [Conditional simulation and Rosenblatt
+  transforms](conditional-simulation.html) develops the multivariate transform
+  and conditional-sampling workflow.
+- The [`vine()` distribution reference](../reference/vine_methods.html) and
+  [vine-copula distribution reference](../reference/vinecop_methods.html)
+  specify the accepted evaluation layouts.

--- a/vignettes/discrete-data.Rmd
+++ b/vignettes/discrete-data.Rmd
@@ -86,7 +86,7 @@ zi_fit <- vine(
   zi_data,
   copula_controls = list(family_set = "indep")
 )
-zi_fit$margins_controls$type
+summary(zi_fit)$margins[, c("name", "type")]
 ```
 
 The atom is always located at zero. A custom zero-inflated margin must return

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -1,0 +1,190 @@
+---
+title: "Getting started with rvinecopulib"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Getting started with rvinecopulib}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(101)
+```
+
+rvinecopulib has three main modeling interfaces. The right one depends on the
+scale of the data and whether the marginal distributions are part of the model.
+
+| Starting point | Function | Result |
+|---|---|---|
+| Original observations | `vine()` | Margins and a vine copula |
+| Uniform pseudo-observations | `vinecop()` | A vine copula |
+| Two uniform variables | `bicop()` | A bivariate copula |
+
+The fitted classes add fit information to distribution classes. A `vine`
+object is also a `vine_dist`, a `vinecop` is also a `vinecop_dist`, and a
+`bicop` is also a `bicop_dist`. Simulation and evaluation therefore use the
+same functions for fitted and manually constructed models.
+
+## A complete model on the data scale
+
+Use `vine()` when the observations are on their original scale. It estimates a
+marginal distribution for every variable, transforms the data to the copula
+scale, and fits the dependence model.
+
+```{r fit-vine}
+n <- 120
+z <- rnorm(n)
+x <- data.frame(
+  amount = exp(z + rnorm(n, sd = 0.5)),
+  duration = exp(0.5 * z + rnorm(n, sd = 0.8)),
+  events = rpois(n, exp(0.3 + 0.25 * z))
+)
+
+fit <- vine(
+  x,
+  var_types = c("c", "c", "d"),
+  copula_controls = list(family_set = "onepar"),
+  keep_data = TRUE
+)
+fit
+summary(fit)
+```
+
+Integer-valued discrete columns are declared with `var_types = "d"`. Ordered
+factors are detected automatically. See [Marginal
+models](marginal-models.html) for the default KDE margins, parametric
+selection, custom margin families, zero inflation, and observation weights.
+
+The fitted object represents the joint distribution. Its density or mass can
+be evaluated on the original data scale, and new observations can be drawn
+with their original column names and types.
+
+```{r use-vine}
+dvine(x[1:4, ], fit)
+predict(fit, x[1:4, ], what = "pdf")
+logLik(fit)
+AIC(fit)
+
+simulated <- rvine(5, fit)
+simulated
+```
+
+`pvine()` and `predict(..., what = "cdf")` approximate a multivariate CDF by
+Monte Carlo. Increase `n_mc` when accurate tail probabilities are important.
+
+## A dependence model on the copula scale
+
+Use `vinecop()` when the margins are not part of the model. Its input consists
+of approximately uniform pseudo-observations. For continuous data,
+`pseudo_obs()` applies scaled ranks column by column.
+
+```{r fit-vinecop}
+u <- pseudo_obs(as.matrix(USArrests))
+copula_fit <- vinecop(
+  u,
+  family_set = c("gaussian", "clayton", "gumbel", "frank")
+)
+summary(copula_fit)
+```
+
+The result can be evaluated and simulated directly on the unit hypercube.
+
+```{r use-vinecop}
+new_u <- rvinecop(6, copula_fit)
+dvinecop(new_u, copula_fit)
+pvinecop(new_u[1:2, ], copula_fit, n_mc = 1000)
+```
+
+Do not apply ordinary ranks blindly to discrete data. Discrete copula models
+need both `F(x)` and its left limit `F(x-)`; the dedicated discrete-data article
+explains the accepted layouts. `vine()` constructs these quantities
+automatically from its fitted margins. See [Vine copula models and
+structures](vine-copula-models.html) for structure selection, truncation,
+thresholding, and model inspection.
+
+## A bivariate model
+
+Use `bicop()` for two-dimensional copula data. It estimates each compatible
+candidate and selects a family using AIC by default.
+
+```{r fit-bicop}
+u2 <- rbicop(200, "clayton", 90, 2)
+bivariate_fit <- bicop(u2, family_set = "par")
+bivariate_fit
+
+dbicop(u2[1:4, ], bivariate_fit)
+tail_dep(bivariate_fit)
+```
+
+The [bivariate-model guide](bivariate-copulas.html) covers rotations,
+h-functions, dependence measures, family sets, vectorized parameters, and
+nonparametric models.
+
+## Fixed and fitted models
+
+The `*_dist()` constructors are useful when the model components are known.
+For example, a Gaussian copula with correlation 0.7 is a complete bivariate
+distribution even though it has not been fitted:
+
+```{r fixed-model}
+fixed <- bicop_dist("gaussian", parameters = 0.7)
+dbicop(c(0.25, 0.8), fixed)
+rbicop(3, fixed)
+```
+
+Fitted objects additionally store a log-likelihood, observation count, and fit
+controls. Set `keep_data = TRUE` only when methods such as `fitted()` need the
+training data.
+
+## Selection controls
+
+The most frequently used controls are:
+
+- `family_set`: candidate pair-copula families or a predefined collection;
+- `selcrit`: `"loglik"`, `"aic"`, `"bic"`, `"mbic"`, or `"mbicv"` where
+  applicable;
+- `par_method`: maximum likelihood (`"mle"`) or Kendall's tau inversion
+  (`"itau"`) for supported families;
+- `allow_rotations`: whether rotated Archimedean families may be selected;
+- `weights`: optional observation weights;
+- `cores`: parallel workers used by supported operations.
+
+`vinecop()` additionally controls structure selection, truncation, and
+thresholding. These options are developed in the vine-model article rather
+than hidden in a single large example.
+
+## Reproducibility and persistence
+
+Ordinary model fitting is deterministic. Simulation uses R's random-number
+state, so `set.seed()` makes it reproducible. Quasi-random simulation is
+available through `qrng = TRUE`.
+
+All model objects can be stored with `saveRDS()` and restored with `readRDS()`.
+Custom margin classes remain usable after restoration as long as their S3
+methods are available in the R session.
+
+```{r persistence}
+path <- tempfile(fileext = ".rds")
+saveRDS(copula_fit, path)
+restored <- readRDS(path)
+unlink(path)
+
+set.seed(102)
+draws1 <- rvinecop(4, copula_fit)
+set.seed(102)
+draws2 <- rvinecop(4, restored)
+stopifnot(isTRUE(all.equal(draws1, draws2)))
+```
+
+## Where to go next
+
+- [Marginal models](marginal-models.html) develops full distributions on the
+  original data scale.
+- [Bivariate copula models](bivariate-copulas.html) documents the pair-copula
+  building blocks and family-selection controls.
+- [Vine copula models and structures](vine-copula-models.html) covers
+  high-dimensional dependence modeling.
+- The [function reference](../reference/index.html) lists the complete API by
+  modeling task.

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -186,5 +186,8 @@ stopifnot(isTRUE(all.equal(draws1, draws2)))
   building blocks and family-selection controls.
 - [Vine copula models and structures](vine-copula-models.html) covers
   high-dimensional dependence modeling.
+- [Discrete data](discrete-data.html), [conditional
+  simulation](conditional-simulation.html), and [likelihood
+  inference](likelihood-inference.html) introduce advanced workflows.
 - The [function reference](../reference/index.html) lists the complete API by
   modeling task.

--- a/vignettes/likelihood-inference.Rmd
+++ b/vignettes/likelihood-inference.Rmd
@@ -1,0 +1,213 @@
+---
+title: "Scores, Hessians, and varying parameters"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Scores, Hessians, and varying parameters}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(601)
+```
+
+rvinecopulib exposes observation-wise likelihood scores and average Hessians
+for parametric bivariate and vine copula models. These are the basic inputs for
+convergence checks, standard errors, sandwich covariance estimates, and
+gradient-based extensions.
+
+For a parameter vector `theta` and observation-wise log-likelihood
+contributions `ell_i(theta)`, rvinecopulib reports
+\[
+s_i(\theta)=\frac{\partial\ell_i(\theta)}{\partial\theta},
+\qquad
+\bar H(\theta)=\frac{1}{n}\sum_{i=1}^n
+\frac{\partial^2\ell_i(\theta)}{\partial\theta\partial\theta^\top}.
+\]
+Thus `scores()` contains the row vectors `s_i`, while `hessian()` returns
+`H-bar`.
+
+## Bivariate scores and Hessians
+
+Fit a parametric model and evaluate derivatives at its fitted parameters:
+
+```{r bicop-derivatives}
+u2 <- rbicop(250, "gaussian", 0, 0.6)
+fit2 <- bicop(u2, family_set = "gaussian")
+
+score2 <- scores(u2, fit2)
+hessian2 <- hessian(u2, fit2)
+dim(score2)
+hessian2
+colSums(score2)
+```
+
+The score matrix has one row per observation and one column per model
+parameter. At an interior maximum-likelihood estimate, its column sums should
+be close to zero. The Hessian is averaged over observations; multiply by the
+sample size when a summed log-likelihood Hessian is required.
+
+These derivatives are available for continuous parametric models. Boundary
+estimates and weakly identified parameters need the same care as in any
+likelihood analysis.
+
+## Vine parameter ordering
+
+For a vine, score columns follow `(tree, edge, parameter)` order: tree 1 from
+left to right, then tree 2, and so on; multi-parameter pair copulas contribute
+their parameters in the order shown by `get_parameters()`.
+
+```{r fit-vine}
+n <- 220
+z <- rnorm(n)
+x <- cbind(
+  z + rnorm(n),
+  0.7 * z + rnorm(n),
+  -0.5 * z + rnorm(n)
+)
+u <- pseudo_obs(x)
+fit <- vinecop(
+  u,
+  structure = dvine_structure(1:3),
+  family_set = "gaussian"
+)
+get_all_parameters(fit)
+```
+
+The number and ordering of derivative columns can be checked against the edge
+summary.
+
+```{r vine-scores}
+score <- scores(u, fit)
+hess <- hessian(u, fit)
+dim(score)
+dim(hess)
+summary(fit)
+```
+
+## Stepwise and full likelihood derivatives
+
+Vine models are usually fitted sequentially. With `step_wise = TRUE` (the
+default), each pair copula treats the pseudo-observations passed down from
+earlier trees as fixed. This is the objective optimized by the sequential
+estimator.
+
+With `step_wise = FALSE`, derivatives propagate through the complete
+h-function cascade and refer to the full joint log-likelihood.
+
+For a vine with edge set `E`, an observation contributes
+\[
+\ell_i(\theta)=\sum_{e\in E}
+\log c_e\{u_{e,1,i}(\theta_{<e}),u_{e,2,i}(\theta_{<e});\theta_e\}.
+\]
+Stepwise derivatives hold the conditional pseudo-observations `u_e` fixed.
+Full derivatives also differentiate their dependence on parameters in earlier
+trees, denoted by `theta_<e` above.
+
+```{r stepwise-full}
+stepwise_gradient <- colSums(scores(u, fit, step_wise = TRUE))
+full_gradient <- colSums(scores(u, fit, step_wise = FALSE))
+rbind(stepwise = stepwise_gradient, full = full_gradient)
+```
+
+The stepwise gradient should be close to zero at a sequential fit. The full
+gradient generally is not: a sequence of conditional maximizations is not the
+same as a joint maximum. This distinction should be stated explicitly whenever
+derivatives are used for inference.
+
+## Reuse density intermediates
+
+`dvinecop(..., keep_all = TRUE)` returns the density and the per-edge values
+computed by the h-function cascade.
+
+```{r keep-all}
+full <- dvinecop(u[1:5, ], fit, keep_all = TRUE)
+names(full)
+full$pdf
+```
+
+The triangular `pdf_edges`, `hfunc1`, and `hfunc2` entries follow the same tree
+and edge ordering as the fitted pair copulas. The `_sub` h-functions contain
+left-limit evaluations for discrete models and are empty for fully continuous
+models.
+
+## Observation-specific bivariate parameters
+
+Parametric copulas can be evaluated with a different parameter set in every
+row. This is useful when another model maps covariates to valid copula
+parameters.
+
+```{r varying-bicop}
+points <- matrix(runif(200), ncol = 2)
+rho <- seq(-0.8, 0.8, length.out = nrow(points))
+
+density <- dbicop(points, "gaussian", 0, parameters = rho)
+score_varying <- scores(points, bicop_dist("gaussian"), parameters = rho)
+hessian_varying <- hessian(
+  points,
+  bicop_dist("gaussian"),
+  parameters = rho
+)
+head(cbind(rho, density, score_varying))
+```
+
+For a one-parameter family, `parameters` may be a vector. Otherwise it must be
+a matrix with one row per observation and one column per family parameter.
+Parameters are not recycled.
+
+## Observation-specific vine parameters
+
+The vine interface takes an `n` by `p` parameter matrix, where `p` is the total
+number of pair-copula parameters and columns use the score ordering.
+
+```{r varying-vine}
+base_parameters <- unlist(get_all_parameters(fit), use.names = FALSE)
+parameter_matrix <- matrix(
+  rep(base_parameters, each = nrow(u)),
+  nrow = nrow(u)
+)
+parameter_matrix[, 1] <- seq(-0.6, 0.6, length.out = nrow(u))
+
+density_varying <- dvinecop(u, fit, parameters = parameter_matrix)
+score_varying <- scores(u, fit, parameters = parameter_matrix)
+head(density_varying)
+dim(score_varying)
+```
+
+Observation-specific vine parameters are supported for continuous,
+all-parametric models. Each row must represent a valid complete parameter
+vector. The model stored in `fit` is not modified.
+
+## From derivatives to uncertainty estimates
+
+The score and Hessian outputs deliberately provide ingredients rather than a
+single universal covariance estimator. The correct assembly depends on whether
+the estimator is stepwise or joint, whether weights or clusters are present,
+and whether robust inference is desired.
+
+For an ordinary interior bivariate MLE, the inverse negative summed Hessian is
+the familiar model-based covariance estimate. More elaborate vine inference
+should account for the sequential estimation scheme instead of treating the
+stepwise estimate as a joint maximum.
+
+In the ordinary independent-observation case, define
+\[
+A=-\bar H, \qquad B=\frac{1}{n}\sum_{i=1}^n s_i s_i^\top.
+\]
+The model-based covariance estimate is `(-n H-bar)^(-1)`, while the usual
+sandwich estimate is `A^(-1) B A^(-1) / n`. Weights, clusters, and sequential
+estimation change how these pieces should be assembled.
+
+## Related documentation
+
+- [Bivariate copula models](bivariate-copulas.html) and [vine copula models and
+  structures](vine-copula-models.html) provide the model definitions used in
+  the examples.
+- [Conditional simulation and Rosenblatt
+  transforms](conditional-simulation.html) explains the h-function cascade
+  that full derivatives propagate through.
+- The [bivariate distribution reference](../reference/bicop_methods.html) and
+  [vine-copula distribution reference](../reference/vinecop_methods.html)
+  specify derivative support and parameter shapes.

--- a/vignettes/marginal-models.Rmd
+++ b/vignettes/marginal-models.Rmd
@@ -290,3 +290,13 @@ restored <- readRDS(path)
 unlink(path)
 all.equal(dvine(x, restored), dvine(x, fit_custom))
 ```
+
+## Related documentation
+
+- [Getting started](getting-started.html) introduces the complete `vine()`
+  modeling workflow.
+- [Discrete, mixed, and zero-inflated data](discrete-data.html) derives the
+  likelihood contributions and documents copula-scale layouts.
+- The [`vine()` reference](../reference/vine.html), [margin-family
+  reference](../reference/margin_family.html), and [fitted-margin
+  protocol](../reference/margin_protocol.html) give complete API contracts.

--- a/vignettes/marginal-models.Rmd
+++ b/vignettes/marginal-models.Rmd
@@ -298,5 +298,7 @@ all.equal(dvine(x, restored), dvine(x, fit_custom))
 - [Discrete, mixed, and zero-inflated data](discrete-data.html) derives the
   likelihood contributions and documents copula-scale layouts.
 - The [`vine()` reference](../reference/vine.html), [margin-family
-  reference](../reference/margin_family.html), and [fitted-margin
-  protocol](../reference/margin_protocol.html) give complete API contracts.
+  constructor](../reference/margin_family.html), [fitted-margin
+  protocol](../reference/margin_protocol.html), and [margin-family
+  protocol](../reference/margin_family_protocol.html) give complete API
+  contracts.

--- a/vignettes/vine-copula-models.Rmd
+++ b/vignettes/vine-copula-models.Rmd
@@ -1,0 +1,232 @@
+---
+title: "Vine copula models and structures"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Vine copula models and structures}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(301)
+```
+
+A vine copula decomposes a multivariate dependence model into a sequence of
+bivariate copulas. The structure determines which conditioned and conditioning
+variables belong to each edge; one `bicop_dist` object supplies the model for
+that edge.
+
+## Read an R-vine structure
+
+Consider the triangular array
+
+```
+4 4 4 4
+3 3 3
+2 2
+1
+```
+
+It represents these pair copulas:
+
+| Tree | Edge | Conditioned pair | Conditioning set |
+|---:|---:|---|---|
+| 1 | 1 | 1, 4 | — |
+| 1 | 2 | 2, 4 | — |
+| 1 | 3 | 3, 4 | — |
+| 2 | 1 | 1, 3 | 4 |
+| 2 | 2 | 2, 3 | 4 |
+| 3 | 1 | 1, 2 | 3, 4 |
+
+In R, the structure can be constructed from its order and off-diagonal rows:
+
+```{r structure}
+structure <- rvine_structure(
+  order = 1:4,
+  struct_array = list(c(4, 4, 4), c(3, 3), 2)
+)
+structure
+as_rvine_matrix(structure)
+```
+
+The square R-vine matrix contains the same information with zeros filling the
+unused triangle. `as_rvine_structure()` converts it back to the compressed
+representation.
+
+`cvine_structure()` and `dvine_structure()` construct the two common
+order-determined special cases. Random valid structures are available through
+`rvine_structure_sim()`.
+
+```{r special-structures}
+cvine_structure(c(4, 1, 3, 2))
+dvine_structure(c(4, 1, 3, 2))
+rvine_structure_sim(4)
+```
+
+See `?rvine_structure` for the complete validity and proximity conditions.
+
+## Construct a vine copula from components
+
+For a three-dimensional model, the first tree has two pair copulas and the
+second has one. The nested list follows `pair_copulas[[tree]][[edge]]`.
+
+```{r construct-model}
+pair_copulas <- list(
+  list(
+    bicop_dist("gaussian", parameters = 0.6),
+    bicop_dist("clayton", parameters = 1.5)
+  ),
+  list(bicop_dist("frank", parameters = 2))
+)
+model <- vinecop_dist(
+  pair_copulas,
+  structure = dvine_structure(1:3)
+)
+model
+summary(model)
+```
+
+The model can immediately be evaluated and simulated:
+
+```{r use-model}
+u <- rvinecop(5, model)
+dvinecop(u, model)
+pvinecop(u[1:2, ], model, n_mc = 1000)
+```
+
+## Fit and select a model
+
+With no structure supplied, `vinecop()` selects trees sequentially using the
+Dissmann algorithm and fits a pair copula on every selected edge.
+
+```{r fit-model}
+n <- 150
+z <- rnorm(n)
+x <- cbind(
+  z + rnorm(n, sd = 0.7),
+  0.6 * z + rnorm(n),
+  -0.4 * z + rnorm(n),
+  rnorm(n)
+)
+u <- pseudo_obs(x)
+
+fit <- vinecop(u, family_set = "onepar", selcrit = "bic")
+fit
+summary(fit)
+```
+
+The most important pair-copula controls (`family_set`, `par_method`,
+`nonpar_method`, `mult`, `selcrit`, `weights`, `presel`, and
+`allow_rotations`) have the same meaning as in `bicop()`. The [bivariate
+copula guide](bivariate-copulas.html) describes the available families,
+rotations, and estimation methods.
+
+## Inspect the selected trees
+
+Getters work on both manually constructed and fitted models. Tree and edge
+indices are one-based in the R interface.
+
+```{r inspect}
+get_structure(fit)
+get_matrix(fit)
+get_pair_copula(fit, tree = 1, edge = 1)
+get_family(fit, tree = 1, edge = 1)
+get_parameters(fit, tree = 1, edge = 1)
+get_ktau(fit, tree = 1, edge = 1)
+get_all_families(fit)
+```
+
+`summary(fit)` returns the edge table invisibly, which is convenient for
+programmatic inspection.
+
+## Control structure selection
+
+The edge weight used to build each tree is selected by `tree_crit`:
+
+- `"tau"` for absolute Kendall's tau;
+- `"rho"` for absolute Spearman's rho;
+- `"hoeffd"` for Hoeffding's D;
+- `"mcor"` for maximum correlation;
+- `"joe"` for a Gaussian-copula mutual-information criterion;
+- a custom function of `data` and `weights`.
+
+`tree_algorithm = "mst_prim"` and `"mst_kruskal"` select a maximum spanning
+tree. `"random_weighted"` and `"random_unweighted"` draw random spanning
+trees, which can be useful in ensemble or exploratory workflows.
+
+```{r structure-controls, eval=FALSE}
+custom_strength <- function(data, weights) {
+  if (length(weights)) {
+    abs(weighted.mean(data[, 1] * data[, 2], weights))
+  } else {
+    abs(mean(data[, 1] * data[, 2]))
+  }
+}
+
+custom_fit <- vinecop(u, tree_crit = custom_strength)
+random_fit <- vinecop(u, tree_algorithm = "random_weighted")
+```
+
+Custom criteria run on the calling thread. Pair-copula fitting may still use
+multiple `cores`.
+
+## Fix all or part of a structure
+
+Supply a full structure to keep it fixed while selecting pair-copula families.
+A truncated structure fixes its existing trees and asks `vinecop()` to select
+the remaining trees up to `trunc_lvl`.
+
+```{r fixed-structure}
+fixed_structure_fit <- vinecop(
+  u,
+  structure = dvine_structure(1:4),
+  family_set = c("gaussian", "clayton")
+)
+
+first_tree <- rvine_structure(order = 1:4, struct_array = list(rep(4, 3)))
+partial_fit <- vinecop(
+  u,
+  structure = first_tree,
+  family_set = "onepar"
+)
+```
+
+## Truncation and thresholding
+
+`trunc_lvl` limits the number of fitted trees. Pair copulas above that level are
+independence copulas. `threshold` replaces edges whose selection strength is
+below the threshold by independence copulas.
+
+```{r sparse-models}
+truncated <- vinecop(u, family_set = "onepar", trunc_lvl = 1)
+thresholded <- vinecop(u, family_set = "onepar", threshold = 0.1)
+truncate_model(fit, trunc_lvl = 1)
+```
+
+Set `trunc_lvl = NA` or `threshold = NA` to select the value automatically with
+mBICV. The fitted threshold and truncation level are visible in the model
+summary.
+
+## Refit an existing model
+
+Pass a fitted model through `vinecop_object` to update parameters while keeping
+its structure and families fixed. This is useful for rolling windows or
+bootstrap samples.
+
+```{r refit}
+refitted <- vinecop(u, vinecop_object = fit)
+stopifnot(identical(get_all_families(refitted), get_all_families(fit)))
+```
+
+For a manually constructed distribution, use `vinecop()` to select from data
+or construct a new `vinecop_dist()` after changing its components.
+
+## Related documentation
+
+- [Bivariate copula models](bivariate-copulas.html) provides the details of
+  the pair-copula building blocks.
+- The [`vinecop()` reference](../reference/vinecop.html) lists all fitting and
+  selection arguments; the [structure reference](../reference/rvine_structure.html)
+  gives the formal matrix validity conditions.

--- a/vignettes/vine-copula-models.Rmd
+++ b/vignettes/vine-copula-models.Rmd
@@ -227,6 +227,13 @@ or construct a new `vinecop_dist()` after changing its components.
 
 - [Bivariate copula models](bivariate-copulas.html) provides the details of
   the pair-copula building blocks.
+- [Discrete, mixed, and zero-inflated data](discrete-data.html) explains the
+  copula-scale representation required when some variables have atoms.
+- [Conditional simulation and Rosenblatt
+  transforms](conditional-simulation.html) describes conditioning-aware
+  structures and sampling orders.
+- [Scores, Hessians, and varying parameters](likelihood-inference.html)
+  explains edge parameter ordering and stepwise versus full derivatives.
 - The [`vinecop()` reference](../reference/vinecop.html) lists all fitting and
   selection arguments; the [structure reference](../reference/rvine_structure.html)
   gives the formal matrix validity conditions.


### PR DESCRIPTION
## Summary

### Documentation foundation

- reorganize the README around capabilities, installation, and representative
  `bicop()` → `vinecop()` → `vine()` examples;
- keep `README.Rmd` as the source and `README.md` for GitHub, without generating
  root-level HTML;
- rewrite the package overview and organize the pkgdown reference by modeling
  task;
- correct stale examples and argument names in existing API documentation.

### Modeling guides

- add getting-started, bivariate-copula, and vine-copula guides;
- document discrete and mixed likelihoods, conditional simulation, continuous
  and randomized-discrete Rosenblatt transforms, scores, Hessians, stepwise
  versus full derivatives, varying parameters, and covariance formulas;
- connect the workflow guides, margins guide, and API reference.

## Rebase status

Rebased onto the consolidated margin-protocol PR #338 after the former margin
stack was folded into one layer. This PR now contains documentation-only work
relative to #338 and reports version `1.0.0.1.0`.

## Validation

- `air format .`;
- `git diff --check`;
- full test suite: 1,049 passed, 0 failed/warned/skipped;
- `R CMD check --no-manual`: 0 errors;
- all package vignettes build successfully.

The check retains the existing compiler-flag warning and system-clock note. It
also reports the documentation branch's existing relative pkgdown link
`../reference/index.html` in the installed getting-started vignette.

## Stack

Top PR in GitHub Stack #346. Depends directly on #338.
