### PR TITLE
Add core modeling guides

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -19,6 +19,13 @@ navbar:
       - text: Margins and data types
       - text: Marginal models
         href: articles/marginal-models.html
+      - text: Discrete, mixed, and zero-inflated data
+        href: articles/discrete-data.html
+      - text: Advanced workflows
+      - text: Conditional simulation and Rosenblatt transforms
+        href: articles/conditional-simulation.html
+      - text: Scores, Hessians, and varying parameters
+        href: articles/likelihood-inference.html
 
 reference:
 - title: Full distributions and margins

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -10,6 +10,13 @@ navbar:
     articles:
       text: Articles
       menu:
+      - text: Getting started
+        href: articles/getting-started.html
+      - text: Bivariate copula models
+        href: articles/bivariate-copulas.html
+      - text: Vine copula models and structures
+        href: articles/vine-copula-models.html
+      - text: Margins and data types
       - text: Marginal models
         href: articles/marginal-models.html
 

--- a/vignettes/bivariate-copulas.Rmd
+++ b/vignettes/bivariate-copulas.Rmd
@@ -1,0 +1,203 @@
+---
+title: "Bivariate copula models"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Bivariate copula models}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(201)
+```
+
+Bivariate copulas are the building blocks of vine models. rvinecopulib can
+construct a known model, fit or select one from data, evaluate its distribution
+functions, and summarize its dependence.
+
+## Implemented families
+
+| Type | Family | Identifier | Parameters |
+|---|---|---|---:|
+| Independence | Independence | `"indep"` | 0 |
+| Elliptical | Gaussian | `"gaussian"` | 1 |
+| Elliptical | Student t | `"t"` | 2 |
+| Archimedean | Clayton | `"clayton"` | 1 |
+| Archimedean | Gumbel | `"gumbel"` | 1 |
+| Archimedean | Frank | `"frank"` | 1 |
+| Archimedean | Joe | `"joe"` | 1 |
+| Archimedean | BB1, BB6, BB7, BB8 | lower-case name | 2 |
+| Extreme value | Tawn | `"tawn"` | 3 |
+| Nonparametric | Transformation kernel | `"tll"` | effective count |
+
+Unambiguous partial names such as `"gauss"` and collection aliases such as
+`"par"` are accepted. For reusable code, full names make intent clearer.
+
+## Construct a known model
+
+`bicop_dist()` specifies a family, rotation, parameters, and variable types.
+
+```{r construct}
+cop <- bicop_dist(
+  family = "clayton",
+  rotation = 90,
+  parameters = 2
+)
+cop
+```
+
+Rotations are `0`, `90`, `180`, or `270` degrees. They allow asymmetric
+Archimedean copulas to represent different corners and negative dependence.
+Elliptical, Frank, independence, and nonparametric copulas already cover both
+signs without rotations.
+
+## Evaluate and simulate
+
+The density, CDF, and random generator follow R's `d*`, `p*`, and `r*`
+conventions.
+
+```{r evaluate}
+points <- rbind(c(0.2, 0.7), c(0.8, 0.3))
+dbicop(points, cop)
+pbicop(points, cop)
+rbicop(4, cop)
+```
+
+The same functions also accept family, rotation, and parameters directly:
+
+```{r direct}
+dbicop(points, "gaussian", 0, 0.6)
+```
+
+## Conditional distributions and h-functions
+
+H-functions are the conditional distributions used recursively in vine
+copulas. If `cond_var = 1`, the first input variable is conditioned on and the
+function returns the conditional CDF of the second. With `inverse = TRUE`, it
+returns the corresponding conditional quantile.
+
+```{r h-functions}
+h <- hbicop(points, cond_var = 1, family = cop)
+h
+hbicop(cbind(points[, 1], h), cond_var = 1, family = cop, inverse = TRUE)
+```
+
+This round trip recovers the second column up to numerical precision. The same
+conditional-distribution operations drive vine recursion and simulation.
+
+## Dependence measures
+
+`par_to_ktau()` converts family parameters to Kendall's tau, and
+`ktau_to_par()` provides the inverse for families where tau determines all
+parameters. Model objects expose Kendall's tau through `get_ktau()`.
+
+```{r dependence}
+par_to_ktau("clayton", 90, 2)
+get_ktau(cop)
+blomqvist_beta(cop)
+tail_dep(cop)
+```
+
+`tail_dep()` reports the four corner tail-dependence coefficients. This is
+especially useful for rotated and asymmetric families, where a single
+lower/upper pair is not enough to describe the model.
+
+## Fit and select from data
+
+`bicop()` expects two approximately uniform columns. It fits every requested
+compatible family and selects the best according to `selcrit`.
+
+```{r selection}
+u <- rbicop(300, "gumbel", 180, 2)
+fit <- bicop(
+  u,
+  family_set = c("gaussian", "clayton", "gumbel", "frank"),
+  selcrit = "bic"
+)
+fit
+summary(fit)
+```
+
+Useful family collections include:
+
+- `"all"`, `"parametric"`, and `"nonparametric"`;
+- `"oneparametric"`, `"twoparametric"`, and `"threeparametric"`;
+- `"elliptical"`, `"archimedean"`, `"ev"`, and `"bbs"`;
+- `"itau"`, the families compatible with Kendall's tau inversion.
+
+Partial matching makes shorter forms such as `"onepar"` and `"par"`
+available. Explicit character vectors are preferable when the candidate set is
+part of a scientific specification.
+
+Maximum likelihood is the default for parametric families. Set
+`par_method = "itau"` for Kendall's tau inversion. The transformation-kernel
+model uses `nonpar_method` and `mult` to control the local-likelihood order and
+smoothing.
+
+## Observation weights and missing values
+
+Pass one nonnegative weight per row with `weights`. The backend standardizes
+weights internally. Missing or zero-weight observations do not contribute to a
+pair fit.
+
+```{r weights}
+weights <- seq_len(nrow(u))
+weighted_fit <- bicop(
+  u,
+  family_set = c("gaussian", "gumbel"),
+  weights = weights
+)
+weighted_fit
+```
+
+## Discrete variables
+
+A discrete copula observation needs both `F(x)` and `F(x-)`. For two discrete
+variables, pass four columns: the two CDF values followed by their two left
+limits. Redundant left-limit columns for continuous variables may be omitted.
+
+```{r discrete}
+counts <- cbind(rpois(80, 2), rpois(80, 3))
+u_discrete <- cbind(
+  ppois(counts[, 1], 2),
+  ppois(counts[, 2], 3),
+  ppois(counts[, 1] - 1, 2),
+  ppois(counts[, 2] - 1, 3)
+)
+fit_discrete <- bicop(
+  u_discrete,
+  var_types = c("d", "d"),
+  family_set = "onepar"
+)
+fit_discrete
+```
+
+The dedicated discrete-data guide covers compact layouts, mixed models, and
+atoms in detail.
+
+## Observation-specific parameters
+
+Evaluation and simulation can use one parameter set per observation without
+constructing many model objects. A one-parameter family accepts a vector;
+multi-parameter families use a matrix with one row per observation.
+
+```{r vectorized}
+rho <- seq(-0.7, 0.7, length.out = nrow(points))
+dbicop(points, "gaussian", 0, parameters = rho)
+rbicop(length(rho), "gaussian", 0, parameters = rho)
+```
+
+This interface is intended for conditional or covariate-dependent copula
+models. Parameters are not recycled, and vectorized evaluation is limited to
+parametric families.
+
+## Related documentation
+
+- [Vine copula models and structures](vine-copula-models.html) shows how
+  bivariate copulas are assembled into a high-dimensional model.
+- The [`bicop()` reference](../reference/bicop.html) lists all fitting
+  controls; [`bicop_dist()` and its distribution
+  functions](../reference/bicop_dist.html) document construction and
+  evaluation.

--- a/vignettes/bivariate-copulas.Rmd
+++ b/vignettes/bivariate-copulas.Rmd
@@ -85,7 +85,9 @@ hbicop(cbind(points[, 1], h), cond_var = 1, family = cop, inverse = TRUE)
 ```
 
 This round trip recovers the second column up to numerical precision. The same
-conditional-distribution operations drive vine recursion and simulation.
+conditional-distribution operations drive vine recursion and simulation; see
+[Conditional simulation and Rosenblatt
+transforms](conditional-simulation.html) for the multivariate workflow.
 
 ## Dependence measures
 
@@ -174,8 +176,8 @@ fit_discrete <- bicop(
 fit_discrete
 ```
 
-The dedicated discrete-data guide covers compact layouts, mixed models, and
-atoms in detail.
+The [discrete-data guide](discrete-data.html) derives the likelihood
+contribution and covers compact layouts, mixed models, and atoms in detail.
 
 ## Observation-specific parameters
 
@@ -197,6 +199,8 @@ parametric families.
 
 - [Vine copula models and structures](vine-copula-models.html) shows how
   bivariate copulas are assembled into a high-dimensional model.
+- [Scores, Hessians, and varying parameters](likelihood-inference.html)
+  documents likelihood derivatives and parameter ordering.
 - The [`bicop()` reference](../reference/bicop.html) lists all fitting
   controls; [`bicop_dist()` and its distribution
   functions](../reference/bicop_dist.html) document construction and

--- a/vignettes/conditional-simulation.Rmd
+++ b/vignettes/conditional-simulation.Rmd
@@ -1,0 +1,200 @@
+---
+title: "Conditional simulation and Rosenblatt transforms"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Conditional simulation and Rosenblatt transforms}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(501)
+```
+
+A vine is simulated along an order. Variables to condition on must form the
+tail of an admissible sampling order. rvinecopulib can enforce this during
+structure selection or transiently reorient a compatible fitted model during
+simulation.
+
+## Select a conditioning-aware structure
+
+Pass variable indices or names through `conditioning_set` when fitting a
+copula. The selected structure places those variables at the end of its order.
+
+```{r select-copula}
+n <- 180
+z <- rnorm(n)
+x <- cbind(
+  response1 = z + rnorm(n),
+  response2 = -0.5 * z + rnorm(n),
+  driver1 = z + rnorm(n, sd = 0.5),
+  driver2 = 0.4 * z + rnorm(n)
+)
+u <- pseudo_obs(x)
+
+fit <- vinecop(
+  u,
+  family_set = "onepar",
+  conditioning_set = c("driver1", "driver2")
+)
+get_structure(fit)
+```
+
+Conditioning-aware selection requires a full, non-truncated vine and an MST
+tree algorithm (`"mst_prim"` or `"mst_kruskal"`). Random tree algorithms do
+not guarantee the required order.
+
+## Simulate conditionally on the copula scale
+
+`u_cond` contains one value per conditioning variable. A vector or one-row
+matrix is repeated for all simulations; an `n`-row matrix specifies different
+conditions for every output row.
+
+```{r conditional-copula}
+condition <- c(0.25, 0.8)
+draws <- rvinecop(
+  100,
+  fit,
+  u_cond = condition,
+  conditioning_set = c("driver1", "driver2")
+)
+stopifnot(
+  isTRUE(all.equal(draws[, "driver1"], rep(condition[1], 100))),
+  isTRUE(all.equal(draws[, "driver2"], rep(condition[2], 100)))
+)
+head(draws)
+```
+
+When `conditioning_set` is omitted, the columns of `u_cond` refer to the last
+variables in the model's current order.
+
+```{r row-specific-conditions}
+conditions <- cbind(
+  driver1 = seq(0.1, 0.9, length.out = 5),
+  driver2 = rep(0.5, 5)
+)
+row_draws <- rvinecop(
+  5,
+  fit,
+  u_cond = conditions,
+  conditioning_set = c("driver1", "driver2")
+)
+stopifnot(isTRUE(all.equal(row_draws[, 3:4], conditions)))
+```
+
+## Condition on the original data scale
+
+`vine()` exposes the same structure control through `copula_controls`.
+`rvine()` accepts `x_cond` on the original scale and uses the fitted margins to
+compute all necessary CDF values and left limits.
+
+```{r conditional-original-scale}
+full_fit <- vine(
+  as.data.frame(x),
+  margins_controls = list(family_set = "kde1d"),
+  copula_controls = list(
+    family_set = "onepar",
+    conditioning_set = c("driver1", "driver2")
+  )
+)
+
+original_condition <- data.frame(driver1 = -0.5, driver2 = 1.25)
+original_draws <- rvine(
+  6,
+  full_fit,
+  x_cond = original_condition,
+  conditioning_set = c("driver1", "driver2")
+)
+stopifnot(
+  isTRUE(all.equal(original_draws[, "driver1"], rep(-0.5, 6))),
+  isTRUE(all.equal(original_draws[, "driver2"], rep(1.25, 6)))
+)
+```
+
+Column names are strongly recommended: they make the mapping explicit and
+protect code from changes in variable order.
+
+## Reorient an existing model transiently
+
+Supplying an explicit `conditioning_set` to `rvinecop()` or `rvine()` asks the
+backend to evaluate an equivalent orientation without modifying the model.
+Only conditioning sets that can form an admissible tail of the fitted
+structure are possible. If a specific set is central to the analysis, request
+it during fitting; selection then guarantees a usable structure.
+
+## Discrete conditioning variables
+
+On the copula scale, a discrete conditioning variable needs its value `F(x)`
+and left limit `F(x-)`. As with model evaluation, `u_cond` accepts:
+
+- a compact layout with one value column per conditioning variable followed by
+  one left-limit column per discrete variable; or
+- an expanded layout with all value columns followed by all left-limit
+  columns, where a continuous variable's two columns must be equal.
+
+`rvine()` handles this internally from `x_cond`, including ordered and
+zero-inflated margins.
+
+## Rosenblatt transforms
+
+The Rosenblatt transform maps observations from a fitted distribution to
+independent uniforms. For continuous variables in a sampling sequence
+`s1, ..., sd`, its components are
+\[
+Z_j = F_{s_j \mid s_1,\ldots,s_{j-1}}
+\left(X_{s_j}\mid X_{s_1},\ldots,X_{s_{j-1}}\right),
+\qquad j=1,\ldots,d,
+\]
+where the first component is unconditional. If the fitted model is correct,
+the `Z_j` are independent standard uniforms. The inverse transform applies the
+corresponding conditional quantiles recursively and therefore maps independent
+uniforms back to the model.
+
+```{r rosenblatt}
+simulated <- rvinecop(100, fit)
+independent <- rosenblatt(simulated, fit)
+reconstructed <- inverse_rosenblatt(independent, fit)
+max(abs(simulated - reconstructed))
+```
+
+The transform follows the model's sampling order. An explicit
+`conditioning_set` requests an admissible order ending in those variables,
+which is useful when conditional quantiles must follow the same orientation as
+conditional simulation.
+
+```{r conditional-rosenblatt}
+transformed <- rosenblatt(
+  simulated,
+  fit,
+  conditioning_set = c("driver1", "driver2")
+)
+inverse_rosenblatt(
+  transformed,
+  fit,
+  conditioning_set = c("driver1", "driver2")
+)[1:3, ]
+```
+
+For discrete variables, the transform randomizes within the jump interval by
+default. See the [discrete-data guide](discrete-data.html) for the randomized
+formula, deterministic upper endpoints, and required copula layouts.
+
+## Reproducibility
+
+Conditional simulation and randomized discrete transforms use R's
+random-number state. Call `set.seed()` immediately before the operation when a
+reproducible draw is required. The original model object is never mutated by a
+conditional simulation or transform.
+
+## Related documentation
+
+- [Vine copula models and structures](vine-copula-models.html) explains the
+  structure order and selection controls used here.
+- [Marginal models](marginal-models.html) documents the transformation between
+  original observations and the copula scale.
+- The [`rvinecop()` reference](../reference/vinecop_methods.html),
+  [`rvine()` reference](../reference/vine_methods.html), and [Rosenblatt
+  reference](../reference/rosenblatt.html) give complete argument and return
+  value details.

--- a/vignettes/discrete-data.Rmd
+++ b/vignettes/discrete-data.Rmd
@@ -1,0 +1,254 @@
+---
+title: "Discrete, mixed, and zero-inflated data"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Discrete, mixed, and zero-inflated data}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(401)
+```
+
+Copula likelihoods for variables with atoms require two probabilities at every
+observation: the CDF value `F(x)` and its left limit `F(x-)`. For an
+integer-valued variable, `F(x-) = F(x - 1)`. Continuous variables satisfy
+`F(x-) = F(x)`.
+
+The high-level `vine()` interface computes these values from fitted margins.
+The copula-only `bicop()` and `vinecop()` interfaces accept them explicitly.
+
+## Discrete variables on the original scale
+
+All ordinary discrete variables are assumed to have integer support. Declare a
+numeric or integer column through `var_types = "d"`.
+
+```{r integer-data}
+n <- 100
+latent <- rnorm(n)
+x <- data.frame(
+  value = latent + rnorm(n),
+  count = rpois(n, exp(0.5 + 0.3 * latent))
+)
+
+fit <- vine(
+  x,
+  var_types = c("c", "d"),
+  copula_controls = list(family_set = "onepar")
+)
+summary(fit)$margins
+dvine(x[1:5, ], fit)
+```
+
+Explicitly discrete columns are checked for finite integer-valued observations.
+This catches accidental declarations of rounded-looking continuous data.
+
+## Ordered factors
+
+Ordered factors are discrete variables whose levels are mapped internally to
+the integer support `0, 1, ...`. Their class and levels are restored after
+simulation.
+
+```{r ordered-data}
+survey <- data.frame(
+  rating = ordered(
+    sample(c("low", "middle", "high"), n, replace = TRUE),
+    levels = c("low", "middle", "high")
+  ),
+  score = rnorm(n)
+)
+
+ordered_fit <- vine(
+  survey,
+  copula_controls = list(family_set = "indep")
+)
+ordered_draws <- rvine(5, ordered_fit)
+str(ordered_draws)
+```
+
+No `var_types` entry is needed because `ordered()` carries the declaration in
+the column class.
+
+## Zero-inflated variables
+
+`zero_inflated()` marks a continuous variable with an atom at zero. It behaves
+like a numeric vector in a data frame and survives ordinary subsetting.
+
+```{r zero-inflated}
+amount <- zero_inflated(c(rep(0, 25), rexp(75)))
+zi_data <- data.frame(amount = amount, score = rnorm(100))
+inherits(zi_data$amount, "zero_inflated")
+
+zi_fit <- vine(
+  zi_data,
+  copula_controls = list(family_set = "indep")
+)
+zi_fit$margins_controls$type
+```
+
+The atom is always located at zero. A custom zero-inflated margin must return
+the atom probability from `dmargin(0, margin)`. rvinecopulib then computes the
+left limit as
+
+```
+pmargin(0, margin) - dmargin(0, margin)
+```
+
+and uses the ordinary CDF away from zero. Alternatively, declare the type with
+`var_types = "zi"`.
+
+## Copula-scale data layouts
+
+Let `d` be the dimension and `k` the number of discrete variables. Copula
+methods accept two layouts:
+
+- **expanded:** `2d` columns, with all `F(x)` columns followed by all `F(x-)`
+  columns;
+- **compact:** `d + k` columns, with the `F(x)` block followed only by
+  left-limit columns for discrete variables, in variable order.
+
+Consider a three-dimensional model with discrete variables 1 and 3.
+
+```{r layouts}
+n <- 80
+raw <- data.frame(
+  first = rpois(n, 2),
+  middle = rnorm(n),
+  last = rpois(n, 4)
+)
+
+values <- cbind(
+  ppois(raw$first, 2),
+  pnorm(raw$middle),
+  ppois(raw$last, 4)
+)
+left_discrete <- cbind(
+  ppois(raw$first - 1, 2),
+  ppois(raw$last - 1, 4)
+)
+compact <- cbind(values, left_discrete)
+
+left_all <- cbind(
+  ppois(raw$first - 1, 2),
+  pnorm(raw$middle),
+  ppois(raw$last - 1, 4)
+)
+expanded <- cbind(values, left_all)
+
+copula_fit <- vinecop(
+  compact,
+  var_types = c("d", "c", "d"),
+  family_set = "indep"
+)
+stopifnot(isTRUE(all.equal(
+  dvinecop(compact, copula_fit),
+  dvinecop(expanded, copula_fit)
+)))
+```
+
+For a mixed bivariate model, this means three columns: the two CDF values and
+the left limit of the discrete variable. Fully discrete bivariate models need
+four columns.
+
+## What the density means
+
+`dbicop()` and `dvinecop()` return the copula density contribution defined as
+the joint density or mass divided by the marginal densities or masses. This
+definition is consistent across continuous, discrete, and mixed models.
+
+For a bivariate model, write
+\[
+u_j = F_j(x_j), \qquad u_j^- = F_j(x_j^-), \qquad
+\Delta_j = u_j - u_j^-.
+\]
+If both variables are discrete, the copula contribution is the rectangle
+probability divided by the two marginal masses:
+\[
+c^*(u_1,u_2) =
+\frac{C(u_1,u_2)-C(u_1^-,u_2)-C(u_1,u_2^-)+C(u_1^-,u_2^-)}
+     {\Delta_1\Delta_2}.
+\]
+If only the first variable is discrete, the corresponding mixed contribution
+is
+\[
+c^*(u_1,u_2) =
+\frac{\partial_2 C(u_1,u_2)-\partial_2 C(u_1^-,u_2)}{\Delta_1}.
+\]
+The continuous density `c(u1, u2)` is recovered when both jump widths vanish.
+Vine likelihoods apply these continuous, mixed, or rectangle contributions
+edge by edge to the appropriate conditional CDF values.
+
+`dvine()` multiplies that contribution by the fitted marginal densities or
+masses and therefore returns the full joint density or probability mass on the
+original scale. In general,
+\[
+f_X(x) = c^*(u,u^-)\prod_{j=1}^d f_j(x_j),
+\]
+where each `f_j` denotes a density or a probability mass as appropriate.
+
+## Simulation
+
+`rvinecop()` always returns one uniform-scale value per variable. It does not
+invent a marginal distribution for a discrete copula variable. Use `rvine()`
+when simulated values should be returned on the original scale with their
+integer, ordered, or zero-inflated margins.
+
+```{r simulation}
+copula_draws <- rvinecop(4, copula_fit)
+dim(copula_draws)
+
+original_draws <- rvine(4, ordered_fit)
+is.ordered(original_draws$rating)
+```
+
+## Rosenblatt transforms with atoms
+
+For an atom, the Rosenblatt transform is an interval rather than a single
+value. By default, `rosenblatt()` randomizes uniformly within that interval so
+the transformed variable is uniform under a correct model. Set
+`randomize_discrete = FALSE` to return the deterministic upper endpoint.
+
+More precisely, if `G_j(· | x_<j)` is the relevant conditional CDF and
+`V_j` is an independent standard uniform variable, the randomized component is
+\[
+Z_j = G_j(x_j^- \mid x_{<j})
+    + V_j\{G_j(x_j \mid x_{<j})-G_j(x_j^- \mid x_{<j})\}.
+\]
+The non-randomized version returns the upper endpoint `G_j(x_j | x_<j)`.
+
+```{r discrete-rosenblatt}
+set.seed(402)
+randomized <- rosenblatt(compact, copula_fit)
+upper_endpoint <- rosenblatt(
+  compact,
+  copula_fit,
+  randomize_discrete = FALSE
+)
+head(randomized)
+head(upper_endpoint)
+```
+
+The randomization uses R's random-number state and is reproducible with
+`set.seed()`.
+
+## Missing observations
+
+Copula fitting discards incomplete observations pair by pair, retaining the
+maximum information available for each edge. Margin implementations decide how
+to handle missing values during marginal fitting; built-in KDE margins support
+the package's established missing-data workflow. Custom `margin_family()`
+fitters should either handle missing values or fail with a useful message.
+
+## Related documentation
+
+- [Marginal models](marginal-models.html) documents how `vine()` fits and
+  evaluates integer, ordered, and zero-inflated margins.
+- [Conditional simulation and Rosenblatt
+  transforms](conditional-simulation.html) develops the multivariate transform
+  and conditional-sampling workflow.
+- The [`vine()` distribution reference](../reference/vine_methods.html) and
+  [vine-copula distribution reference](../reference/vinecop_methods.html)
+  specify the accepted evaluation layouts.

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -1,0 +1,190 @@
+---
+title: "Getting started with rvinecopulib"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Getting started with rvinecopulib}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(101)
+```
+
+rvinecopulib has three main modeling interfaces. The right one depends on the
+scale of the data and whether the marginal distributions are part of the model.
+
+| Starting point | Function | Result |
+|---|---|---|
+| Original observations | `vine()` | Margins and a vine copula |
+| Uniform pseudo-observations | `vinecop()` | A vine copula |
+| Two uniform variables | `bicop()` | A bivariate copula |
+
+The fitted classes add fit information to distribution classes. A `vine`
+object is also a `vine_dist`, a `vinecop` is also a `vinecop_dist`, and a
+`bicop` is also a `bicop_dist`. Simulation and evaluation therefore use the
+same functions for fitted and manually constructed models.
+
+## A complete model on the data scale
+
+Use `vine()` when the observations are on their original scale. It estimates a
+marginal distribution for every variable, transforms the data to the copula
+scale, and fits the dependence model.
+
+```{r fit-vine}
+n <- 120
+z <- rnorm(n)
+x <- data.frame(
+  amount = exp(z + rnorm(n, sd = 0.5)),
+  duration = exp(0.5 * z + rnorm(n, sd = 0.8)),
+  events = rpois(n, exp(0.3 + 0.25 * z))
+)
+
+fit <- vine(
+  x,
+  var_types = c("c", "c", "d"),
+  copula_controls = list(family_set = "onepar"),
+  keep_data = TRUE
+)
+fit
+summary(fit)
+```
+
+Integer-valued discrete columns are declared with `var_types = "d"`. Ordered
+factors are detected automatically. See [Marginal
+models](marginal-models.html) for the default KDE margins, parametric
+selection, custom margin families, zero inflation, and observation weights.
+
+The fitted object represents the joint distribution. Its density or mass can
+be evaluated on the original data scale, and new observations can be drawn
+with their original column names and types.
+
+```{r use-vine}
+dvine(x[1:4, ], fit)
+predict(fit, x[1:4, ], what = "pdf")
+logLik(fit)
+AIC(fit)
+
+simulated <- rvine(5, fit)
+simulated
+```
+
+`pvine()` and `predict(..., what = "cdf")` approximate a multivariate CDF by
+Monte Carlo. Increase `n_mc` when accurate tail probabilities are important.
+
+## A dependence model on the copula scale
+
+Use `vinecop()` when the margins are not part of the model. Its input consists
+of approximately uniform pseudo-observations. For continuous data,
+`pseudo_obs()` applies scaled ranks column by column.
+
+```{r fit-vinecop}
+u <- pseudo_obs(as.matrix(USArrests))
+copula_fit <- vinecop(
+  u,
+  family_set = c("gaussian", "clayton", "gumbel", "frank")
+)
+summary(copula_fit)
+```
+
+The result can be evaluated and simulated directly on the unit hypercube.
+
+```{r use-vinecop}
+new_u <- rvinecop(6, copula_fit)
+dvinecop(new_u, copula_fit)
+pvinecop(new_u[1:2, ], copula_fit, n_mc = 1000)
+```
+
+Do not apply ordinary ranks blindly to discrete data. Discrete copula models
+need both `F(x)` and its left limit `F(x-)`; the dedicated discrete-data article
+explains the accepted layouts. `vine()` constructs these quantities
+automatically from its fitted margins. See [Vine copula models and
+structures](vine-copula-models.html) for structure selection, truncation,
+thresholding, and model inspection.
+
+## A bivariate model
+
+Use `bicop()` for two-dimensional copula data. It estimates each compatible
+candidate and selects a family using AIC by default.
+
+```{r fit-bicop}
+u2 <- rbicop(200, "clayton", 90, 2)
+bivariate_fit <- bicop(u2, family_set = "par")
+bivariate_fit
+
+dbicop(u2[1:4, ], bivariate_fit)
+tail_dep(bivariate_fit)
+```
+
+The [bivariate-model guide](bivariate-copulas.html) covers rotations,
+h-functions, dependence measures, family sets, vectorized parameters, and
+nonparametric models.
+
+## Fixed and fitted models
+
+The `*_dist()` constructors are useful when the model components are known.
+For example, a Gaussian copula with correlation 0.7 is a complete bivariate
+distribution even though it has not been fitted:
+
+```{r fixed-model}
+fixed <- bicop_dist("gaussian", parameters = 0.7)
+dbicop(c(0.25, 0.8), fixed)
+rbicop(3, fixed)
+```
+
+Fitted objects additionally store a log-likelihood, observation count, and fit
+controls. Set `keep_data = TRUE` only when methods such as `fitted()` need the
+training data.
+
+## Selection controls
+
+The most frequently used controls are:
+
+- `family_set`: candidate pair-copula families or a predefined collection;
+- `selcrit`: `"loglik"`, `"aic"`, `"bic"`, `"mbic"`, or `"mbicv"` where
+  applicable;
+- `par_method`: maximum likelihood (`"mle"`) or Kendall's tau inversion
+  (`"itau"`) for supported families;
+- `allow_rotations`: whether rotated Archimedean families may be selected;
+- `weights`: optional observation weights;
+- `cores`: parallel workers used by supported operations.
+
+`vinecop()` additionally controls structure selection, truncation, and
+thresholding. These options are developed in the vine-model article rather
+than hidden in a single large example.
+
+## Reproducibility and persistence
+
+Ordinary model fitting is deterministic. Simulation uses R's random-number
+state, so `set.seed()` makes it reproducible. Quasi-random simulation is
+available through `qrng = TRUE`.
+
+All model objects can be stored with `saveRDS()` and restored with `readRDS()`.
+Custom margin classes remain usable after restoration as long as their S3
+methods are available in the R session.
+
+```{r persistence}
+path <- tempfile(fileext = ".rds")
+saveRDS(copula_fit, path)
+restored <- readRDS(path)
+unlink(path)
+
+set.seed(102)
+draws1 <- rvinecop(4, copula_fit)
+set.seed(102)
+draws2 <- rvinecop(4, restored)
+stopifnot(isTRUE(all.equal(draws1, draws2)))
+```
+
+## Where to go next
+
+- [Marginal models](marginal-models.html) develops full distributions on the
+  original data scale.
+- [Bivariate copula models](bivariate-copulas.html) documents the pair-copula
+  building blocks and family-selection controls.
+- [Vine copula models and structures](vine-copula-models.html) covers
+  high-dimensional dependence modeling.
+- The [function reference](../reference/index.html) lists the complete API by
+  modeling task.

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -186,5 +186,8 @@ stopifnot(isTRUE(all.equal(draws1, draws2)))
   building blocks and family-selection controls.
 - [Vine copula models and structures](vine-copula-models.html) covers
   high-dimensional dependence modeling.
+- [Discrete data](discrete-data.html), [conditional
+  simulation](conditional-simulation.html), and [likelihood
+  inference](likelihood-inference.html) introduce advanced workflows.
 - The [function reference](../reference/index.html) lists the complete API by
   modeling task.

--- a/vignettes/likelihood-inference.Rmd
+++ b/vignettes/likelihood-inference.Rmd
@@ -1,0 +1,213 @@
+---
+title: "Scores, Hessians, and varying parameters"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Scores, Hessians, and varying parameters}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(601)
+```
+
+rvinecopulib exposes observation-wise likelihood scores and average Hessians
+for parametric bivariate and vine copula models. These are the basic inputs for
+convergence checks, standard errors, sandwich covariance estimates, and
+gradient-based extensions.
+
+For a parameter vector `theta` and observation-wise log-likelihood
+contributions `ell_i(theta)`, rvinecopulib reports
+\[
+s_i(\theta)=\frac{\partial\ell_i(\theta)}{\partial\theta},
+\qquad
+\bar H(\theta)=\frac{1}{n}\sum_{i=1}^n
+\frac{\partial^2\ell_i(\theta)}{\partial\theta\partial\theta^\top}.
+\]
+Thus `scores()` contains the row vectors `s_i`, while `hessian()` returns
+`H-bar`.
+
+## Bivariate scores and Hessians
+
+Fit a parametric model and evaluate derivatives at its fitted parameters:
+
+```{r bicop-derivatives}
+u2 <- rbicop(250, "gaussian", 0, 0.6)
+fit2 <- bicop(u2, family_set = "gaussian")
+
+score2 <- scores(u2, fit2)
+hessian2 <- hessian(u2, fit2)
+dim(score2)
+hessian2
+colSums(score2)
+```
+
+The score matrix has one row per observation and one column per model
+parameter. At an interior maximum-likelihood estimate, its column sums should
+be close to zero. The Hessian is averaged over observations; multiply by the
+sample size when a summed log-likelihood Hessian is required.
+
+These derivatives are available for continuous parametric models. Boundary
+estimates and weakly identified parameters need the same care as in any
+likelihood analysis.
+
+## Vine parameter ordering
+
+For a vine, score columns follow `(tree, edge, parameter)` order: tree 1 from
+left to right, then tree 2, and so on; multi-parameter pair copulas contribute
+their parameters in the order shown by `get_parameters()`.
+
+```{r fit-vine}
+n <- 220
+z <- rnorm(n)
+x <- cbind(
+  z + rnorm(n),
+  0.7 * z + rnorm(n),
+  -0.5 * z + rnorm(n)
+)
+u <- pseudo_obs(x)
+fit <- vinecop(
+  u,
+  structure = dvine_structure(1:3),
+  family_set = "gaussian"
+)
+get_all_parameters(fit)
+```
+
+The number and ordering of derivative columns can be checked against the edge
+summary.
+
+```{r vine-scores}
+score <- scores(u, fit)
+hess <- hessian(u, fit)
+dim(score)
+dim(hess)
+summary(fit)
+```
+
+## Stepwise and full likelihood derivatives
+
+Vine models are usually fitted sequentially. With `step_wise = TRUE` (the
+default), each pair copula treats the pseudo-observations passed down from
+earlier trees as fixed. This is the objective optimized by the sequential
+estimator.
+
+With `step_wise = FALSE`, derivatives propagate through the complete
+h-function cascade and refer to the full joint log-likelihood.
+
+For a vine with edge set `E`, an observation contributes
+\[
+\ell_i(\theta)=\sum_{e\in E}
+\log c_e\{u_{e,1,i}(\theta_{<e}),u_{e,2,i}(\theta_{<e});\theta_e\}.
+\]
+Stepwise derivatives hold the conditional pseudo-observations `u_e` fixed.
+Full derivatives also differentiate their dependence on parameters in earlier
+trees, denoted by `theta_<e` above.
+
+```{r stepwise-full}
+stepwise_gradient <- colSums(scores(u, fit, step_wise = TRUE))
+full_gradient <- colSums(scores(u, fit, step_wise = FALSE))
+rbind(stepwise = stepwise_gradient, full = full_gradient)
+```
+
+The stepwise gradient should be close to zero at a sequential fit. The full
+gradient generally is not: a sequence of conditional maximizations is not the
+same as a joint maximum. This distinction should be stated explicitly whenever
+derivatives are used for inference.
+
+## Reuse density intermediates
+
+`dvinecop(..., keep_all = TRUE)` returns the density and the per-edge values
+computed by the h-function cascade.
+
+```{r keep-all}
+full <- dvinecop(u[1:5, ], fit, keep_all = TRUE)
+names(full)
+full$pdf
+```
+
+The triangular `pdf_edges`, `hfunc1`, and `hfunc2` entries follow the same tree
+and edge ordering as the fitted pair copulas. The `_sub` h-functions contain
+left-limit evaluations for discrete models and are empty for fully continuous
+models.
+
+## Observation-specific bivariate parameters
+
+Parametric copulas can be evaluated with a different parameter set in every
+row. This is useful when another model maps covariates to valid copula
+parameters.
+
+```{r varying-bicop}
+points <- matrix(runif(200), ncol = 2)
+rho <- seq(-0.8, 0.8, length.out = nrow(points))
+
+density <- dbicop(points, "gaussian", 0, parameters = rho)
+score_varying <- scores(points, bicop_dist("gaussian"), parameters = rho)
+hessian_varying <- hessian(
+  points,
+  bicop_dist("gaussian"),
+  parameters = rho
+)
+head(cbind(rho, density, score_varying))
+```
+
+For a one-parameter family, `parameters` may be a vector. Otherwise it must be
+a matrix with one row per observation and one column per family parameter.
+Parameters are not recycled.
+
+## Observation-specific vine parameters
+
+The vine interface takes an `n` by `p` parameter matrix, where `p` is the total
+number of pair-copula parameters and columns use the score ordering.
+
+```{r varying-vine}
+base_parameters <- unlist(get_all_parameters(fit), use.names = FALSE)
+parameter_matrix <- matrix(
+  rep(base_parameters, each = nrow(u)),
+  nrow = nrow(u)
+)
+parameter_matrix[, 1] <- seq(-0.6, 0.6, length.out = nrow(u))
+
+density_varying <- dvinecop(u, fit, parameters = parameter_matrix)
+score_varying <- scores(u, fit, parameters = parameter_matrix)
+head(density_varying)
+dim(score_varying)
+```
+
+Observation-specific vine parameters are supported for continuous,
+all-parametric models. Each row must represent a valid complete parameter
+vector. The model stored in `fit` is not modified.
+
+## From derivatives to uncertainty estimates
+
+The score and Hessian outputs deliberately provide ingredients rather than a
+single universal covariance estimator. The correct assembly depends on whether
+the estimator is stepwise or joint, whether weights or clusters are present,
+and whether robust inference is desired.
+
+For an ordinary interior bivariate MLE, the inverse negative summed Hessian is
+the familiar model-based covariance estimate. More elaborate vine inference
+should account for the sequential estimation scheme instead of treating the
+stepwise estimate as a joint maximum.
+
+In the ordinary independent-observation case, define
+\[
+A=-\bar H, \qquad B=\frac{1}{n}\sum_{i=1}^n s_i s_i^\top.
+\]
+The model-based covariance estimate is `(-n H-bar)^(-1)`, while the usual
+sandwich estimate is `A^(-1) B A^(-1) / n`. Weights, clusters, and sequential
+estimation change how these pieces should be assembled.
+
+## Related documentation
+
+- [Bivariate copula models](bivariate-copulas.html) and [vine copula models and
+  structures](vine-copula-models.html) provide the model definitions used in
+  the examples.
+- [Conditional simulation and Rosenblatt
+  transforms](conditional-simulation.html) explains the h-function cascade
+  that full derivatives propagate through.
+- The [bivariate distribution reference](../reference/bicop_methods.html) and
+  [vine-copula distribution reference](../reference/vinecop_methods.html)
+  specify derivative support and parameter shapes.

--- a/vignettes/marginal-models.Rmd
+++ b/vignettes/marginal-models.Rmd
@@ -256,3 +256,13 @@ restored <- readRDS(path)
 unlink(path)
 all.equal(dvine(x, restored), dvine(x, fit_custom))
 ```
+
+## Related documentation
+
+- [Getting started](getting-started.html) introduces the complete `vine()`
+  modeling workflow.
+- [Discrete, mixed, and zero-inflated data](discrete-data.html) derives the
+  likelihood contributions and documents copula-scale layouts.
+- The [`vine()` reference](../reference/vine.html), [margin-family
+  reference](../reference/margin_family.html), and [fitted-margin
+  protocol](../reference/margin_protocol.html) give complete API contracts.

--- a/vignettes/vine-copula-models.Rmd
+++ b/vignettes/vine-copula-models.Rmd
@@ -1,0 +1,232 @@
+---
+title: "Vine copula models and structures"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Vine copula models and structures}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(301)
+```
+
+A vine copula decomposes a multivariate dependence model into a sequence of
+bivariate copulas. The structure determines which conditioned and conditioning
+variables belong to each edge; one `bicop_dist` object supplies the model for
+that edge.
+
+## Read an R-vine structure
+
+Consider the triangular array
+
+```
+4 4 4 4
+3 3 3
+2 2
+1
+```
+
+It represents these pair copulas:
+
+| Tree | Edge | Conditioned pair | Conditioning set |
+|---:|---:|---|---|
+| 1 | 1 | 1, 4 | — |
+| 1 | 2 | 2, 4 | — |
+| 1 | 3 | 3, 4 | — |
+| 2 | 1 | 1, 3 | 4 |
+| 2 | 2 | 2, 3 | 4 |
+| 3 | 1 | 1, 2 | 3, 4 |
+
+In R, the structure can be constructed from its order and off-diagonal rows:
+
+```{r structure}
+structure <- rvine_structure(
+  order = 1:4,
+  struct_array = list(c(4, 4, 4), c(3, 3), 2)
+)
+structure
+as_rvine_matrix(structure)
+```
+
+The square R-vine matrix contains the same information with zeros filling the
+unused triangle. `as_rvine_structure()` converts it back to the compressed
+representation.
+
+`cvine_structure()` and `dvine_structure()` construct the two common
+order-determined special cases. Random valid structures are available through
+`rvine_structure_sim()`.
+
+```{r special-structures}
+cvine_structure(c(4, 1, 3, 2))
+dvine_structure(c(4, 1, 3, 2))
+rvine_structure_sim(4)
+```
+
+See `?rvine_structure` for the complete validity and proximity conditions.
+
+## Construct a vine copula from components
+
+For a three-dimensional model, the first tree has two pair copulas and the
+second has one. The nested list follows `pair_copulas[[tree]][[edge]]`.
+
+```{r construct-model}
+pair_copulas <- list(
+  list(
+    bicop_dist("gaussian", parameters = 0.6),
+    bicop_dist("clayton", parameters = 1.5)
+  ),
+  list(bicop_dist("frank", parameters = 2))
+)
+model <- vinecop_dist(
+  pair_copulas,
+  structure = dvine_structure(1:3)
+)
+model
+summary(model)
+```
+
+The model can immediately be evaluated and simulated:
+
+```{r use-model}
+u <- rvinecop(5, model)
+dvinecop(u, model)
+pvinecop(u[1:2, ], model, n_mc = 1000)
+```
+
+## Fit and select a model
+
+With no structure supplied, `vinecop()` selects trees sequentially using the
+Dissmann algorithm and fits a pair copula on every selected edge.
+
+```{r fit-model}
+n <- 150
+z <- rnorm(n)
+x <- cbind(
+  z + rnorm(n, sd = 0.7),
+  0.6 * z + rnorm(n),
+  -0.4 * z + rnorm(n),
+  rnorm(n)
+)
+u <- pseudo_obs(x)
+
+fit <- vinecop(u, family_set = "onepar", selcrit = "bic")
+fit
+summary(fit)
+```
+
+The most important pair-copula controls (`family_set`, `par_method`,
+`nonpar_method`, `mult`, `selcrit`, `weights`, `presel`, and
+`allow_rotations`) have the same meaning as in `bicop()`. The [bivariate
+copula guide](bivariate-copulas.html) describes the available families,
+rotations, and estimation methods.
+
+## Inspect the selected trees
+
+Getters work on both manually constructed and fitted models. Tree and edge
+indices are one-based in the R interface.
+
+```{r inspect}
+get_structure(fit)
+get_matrix(fit)
+get_pair_copula(fit, tree = 1, edge = 1)
+get_family(fit, tree = 1, edge = 1)
+get_parameters(fit, tree = 1, edge = 1)
+get_ktau(fit, tree = 1, edge = 1)
+get_all_families(fit)
+```
+
+`summary(fit)` returns the edge table invisibly, which is convenient for
+programmatic inspection.
+
+## Control structure selection
+
+The edge weight used to build each tree is selected by `tree_crit`:
+
+- `"tau"` for absolute Kendall's tau;
+- `"rho"` for absolute Spearman's rho;
+- `"hoeffd"` for Hoeffding's D;
+- `"mcor"` for maximum correlation;
+- `"joe"` for a Gaussian-copula mutual-information criterion;
+- a custom function of `data` and `weights`.
+
+`tree_algorithm = "mst_prim"` and `"mst_kruskal"` select a maximum spanning
+tree. `"random_weighted"` and `"random_unweighted"` draw random spanning
+trees, which can be useful in ensemble or exploratory workflows.
+
+```{r structure-controls, eval=FALSE}
+custom_strength <- function(data, weights) {
+  if (length(weights)) {
+    abs(weighted.mean(data[, 1] * data[, 2], weights))
+  } else {
+    abs(mean(data[, 1] * data[, 2]))
+  }
+}
+
+custom_fit <- vinecop(u, tree_crit = custom_strength)
+random_fit <- vinecop(u, tree_algorithm = "random_weighted")
+```
+
+Custom criteria run on the calling thread. Pair-copula fitting may still use
+multiple `cores`.
+
+## Fix all or part of a structure
+
+Supply a full structure to keep it fixed while selecting pair-copula families.
+A truncated structure fixes its existing trees and asks `vinecop()` to select
+the remaining trees up to `trunc_lvl`.
+
+```{r fixed-structure}
+fixed_structure_fit <- vinecop(
+  u,
+  structure = dvine_structure(1:4),
+  family_set = c("gaussian", "clayton")
+)
+
+first_tree <- rvine_structure(order = 1:4, struct_array = list(rep(4, 3)))
+partial_fit <- vinecop(
+  u,
+  structure = first_tree,
+  family_set = "onepar"
+)
+```
+
+## Truncation and thresholding
+
+`trunc_lvl` limits the number of fitted trees. Pair copulas above that level are
+independence copulas. `threshold` replaces edges whose selection strength is
+below the threshold by independence copulas.
+
+```{r sparse-models}
+truncated <- vinecop(u, family_set = "onepar", trunc_lvl = 1)
+thresholded <- vinecop(u, family_set = "onepar", threshold = 0.1)
+truncate_model(fit, trunc_lvl = 1)
+```
+
+Set `trunc_lvl = NA` or `threshold = NA` to select the value automatically with
+mBICV. The fitted threshold and truncation level are visible in the model
+summary.
+
+## Refit an existing model
+
+Pass a fitted model through `vinecop_object` to update parameters while keeping
+its structure and families fixed. This is useful for rolling windows or
+bootstrap samples.
+
+```{r refit}
+refitted <- vinecop(u, vinecop_object = fit)
+stopifnot(identical(get_all_families(refitted), get_all_families(fit)))
+```
+
+For a manually constructed distribution, use `vinecop()` to select from data
+or construct a new `vinecop_dist()` after changing its components.
+
+## Related documentation
+
+- [Bivariate copula models](bivariate-copulas.html) provides the details of
+  the pair-copula building blocks.
+- The [`vinecop()` reference](../reference/vinecop.html) lists all fitting and
+  selection arguments; the [structure reference](../reference/rvine_structure.html)
+  gives the formal matrix validity conditions.

--- a/vignettes/vine-copula-models.Rmd
+++ b/vignettes/vine-copula-models.Rmd
@@ -227,6 +227,13 @@ or construct a new `vinecop_dist()` after changing its components.
 
 - [Bivariate copula models](bivariate-copulas.html) provides the details of
   the pair-copula building blocks.
+- [Discrete, mixed, and zero-inflated data](discrete-data.html) explains the
+  copula-scale representation required when some variables have atoms.
+- [Conditional simulation and Rosenblatt
+  transforms](conditional-simulation.html) describes conditioning-aware
+  structures and sampling orders.
+- [Scores, Hessians, and varying parameters](likelihood-inference.html)
+  explains edge parameter ordering and stepwise versus full derivatives.
 - The [`vinecop()` reference](../reference/vinecop.html) lists all fitting and
   selection arguments; the [structure reference](../reference/rvine_structure.html)
   gives the formal matrix validity conditions.


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by #331 and #332. Do not merge this documentation stack yet.**
> After both PRs merge into `dev`, rebase the margin stack (#334–#338) and
> documentation stack (#339–#341), confirm version `1.0.0.1.0`, and rerun the
> rendered documentation checks.

Second documentation layer in stack #336; based on #339 and followed by #341.

## Summary

- add a getting-started guide covering the three modeling levels;
- add a bivariate-copula guide covering families, rotations, h-functions,
  dependence measures, selection, weights, and discrete inputs;
- add a vine-copula guide covering structures, construction, selection,
  inspection, sparsity controls, and refitting;
- connect the guides to each other and to the relevant API reference pages.

## Validation

- all three vignettes render successfully;
- `pkgdown::check_pkgdown(".")`;
- `git diff --check`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
