### PR TITLE
Document advanced modeling workflows

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -19,6 +19,13 @@ navbar:
       - text: Margins and data types
       - text: Marginal models
         href: articles/marginal-models.html
+      - text: Discrete, mixed, and zero-inflated data
+        href: articles/discrete-data.html
+      - text: Advanced workflows
+      - text: Conditional simulation and Rosenblatt transforms
+        href: articles/conditional-simulation.html
+      - text: Scores, Hessians, and varying parameters
+        href: articles/likelihood-inference.html
 
 reference:
 - title: Full distributions and margins

--- a/vignettes/bivariate-copulas.Rmd
+++ b/vignettes/bivariate-copulas.Rmd
@@ -85,7 +85,9 @@ hbicop(cbind(points[, 1], h), cond_var = 1, family = cop, inverse = TRUE)
 ```
 
 This round trip recovers the second column up to numerical precision. The same
-conditional-distribution operations drive vine recursion and simulation.
+conditional-distribution operations drive vine recursion and simulation; see
+[Conditional simulation and Rosenblatt
+transforms](conditional-simulation.html) for the multivariate workflow.
 
 ## Dependence measures
 
@@ -174,8 +176,8 @@ fit_discrete <- bicop(
 fit_discrete
 ```
 
-The dedicated discrete-data guide covers compact layouts, mixed models, and
-atoms in detail.
+The [discrete-data guide](discrete-data.html) derives the likelihood
+contribution and covers compact layouts, mixed models, and atoms in detail.
 
 ## Observation-specific parameters
 
@@ -197,6 +199,8 @@ parametric families.
 
 - [Vine copula models and structures](vine-copula-models.html) shows how
   bivariate copulas are assembled into a high-dimensional model.
+- [Scores, Hessians, and varying parameters](likelihood-inference.html)
+  documents likelihood derivatives and parameter ordering.
 - The [`bicop()` reference](../reference/bicop.html) lists all fitting
   controls; [`bicop_dist()` and its distribution
   functions](../reference/bicop_dist.html) document construction and

--- a/vignettes/conditional-simulation.Rmd
+++ b/vignettes/conditional-simulation.Rmd
@@ -1,0 +1,200 @@
+---
+title: "Conditional simulation and Rosenblatt transforms"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Conditional simulation and Rosenblatt transforms}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(501)
+```
+
+A vine is simulated along an order. Variables to condition on must form the
+tail of an admissible sampling order. rvinecopulib can enforce this during
+structure selection or transiently reorient a compatible fitted model during
+simulation.
+
+## Select a conditioning-aware structure
+
+Pass variable indices or names through `conditioning_set` when fitting a
+copula. The selected structure places those variables at the end of its order.
+
+```{r select-copula}
+n <- 180
+z <- rnorm(n)
+x <- cbind(
+  response1 = z + rnorm(n),
+  response2 = -0.5 * z + rnorm(n),
+  driver1 = z + rnorm(n, sd = 0.5),
+  driver2 = 0.4 * z + rnorm(n)
+)
+u <- pseudo_obs(x)
+
+fit <- vinecop(
+  u,
+  family_set = "onepar",
+  conditioning_set = c("driver1", "driver2")
+)
+get_structure(fit)
+```
+
+Conditioning-aware selection requires a full, non-truncated vine and an MST
+tree algorithm (`"mst_prim"` or `"mst_kruskal"`). Random tree algorithms do
+not guarantee the required order.
+
+## Simulate conditionally on the copula scale
+
+`u_cond` contains one value per conditioning variable. A vector or one-row
+matrix is repeated for all simulations; an `n`-row matrix specifies different
+conditions for every output row.
+
+```{r conditional-copula}
+condition <- c(0.25, 0.8)
+draws <- rvinecop(
+  100,
+  fit,
+  u_cond = condition,
+  conditioning_set = c("driver1", "driver2")
+)
+stopifnot(
+  isTRUE(all.equal(draws[, "driver1"], rep(condition[1], 100))),
+  isTRUE(all.equal(draws[, "driver2"], rep(condition[2], 100)))
+)
+head(draws)
+```
+
+When `conditioning_set` is omitted, the columns of `u_cond` refer to the last
+variables in the model's current order.
+
+```{r row-specific-conditions}
+conditions <- cbind(
+  driver1 = seq(0.1, 0.9, length.out = 5),
+  driver2 = rep(0.5, 5)
+)
+row_draws <- rvinecop(
+  5,
+  fit,
+  u_cond = conditions,
+  conditioning_set = c("driver1", "driver2")
+)
+stopifnot(isTRUE(all.equal(row_draws[, 3:4], conditions)))
+```
+
+## Condition on the original data scale
+
+`vine()` exposes the same structure control through `copula_controls`.
+`rvine()` accepts `x_cond` on the original scale and uses the fitted margins to
+compute all necessary CDF values and left limits.
+
+```{r conditional-original-scale}
+full_fit <- vine(
+  as.data.frame(x),
+  margins_controls = list(family_set = "kde1d"),
+  copula_controls = list(
+    family_set = "onepar",
+    conditioning_set = c("driver1", "driver2")
+  )
+)
+
+original_condition <- data.frame(driver1 = -0.5, driver2 = 1.25)
+original_draws <- rvine(
+  6,
+  full_fit,
+  x_cond = original_condition,
+  conditioning_set = c("driver1", "driver2")
+)
+stopifnot(
+  isTRUE(all.equal(original_draws[, "driver1"], rep(-0.5, 6))),
+  isTRUE(all.equal(original_draws[, "driver2"], rep(1.25, 6)))
+)
+```
+
+Column names are strongly recommended: they make the mapping explicit and
+protect code from changes in variable order.
+
+## Reorient an existing model transiently
+
+Supplying an explicit `conditioning_set` to `rvinecop()` or `rvine()` asks the
+backend to evaluate an equivalent orientation without modifying the model.
+Only conditioning sets that can form an admissible tail of the fitted
+structure are possible. If a specific set is central to the analysis, request
+it during fitting; selection then guarantees a usable structure.
+
+## Discrete conditioning variables
+
+On the copula scale, a discrete conditioning variable needs its value `F(x)`
+and left limit `F(x-)`. As with model evaluation, `u_cond` accepts:
+
+- a compact layout with one value column per conditioning variable followed by
+  one left-limit column per discrete variable; or
+- an expanded layout with all value columns followed by all left-limit
+  columns, where a continuous variable's two columns must be equal.
+
+`rvine()` handles this internally from `x_cond`, including ordered and
+zero-inflated margins.
+
+## Rosenblatt transforms
+
+The Rosenblatt transform maps observations from a fitted distribution to
+independent uniforms. For continuous variables in a sampling sequence
+`s1, ..., sd`, its components are
+\[
+Z_j = F_{s_j \mid s_1,\ldots,s_{j-1}}
+\left(X_{s_j}\mid X_{s_1},\ldots,X_{s_{j-1}}\right),
+\qquad j=1,\ldots,d,
+\]
+where the first component is unconditional. If the fitted model is correct,
+the `Z_j` are independent standard uniforms. The inverse transform applies the
+corresponding conditional quantiles recursively and therefore maps independent
+uniforms back to the model.
+
+```{r rosenblatt}
+simulated <- rvinecop(100, fit)
+independent <- rosenblatt(simulated, fit)
+reconstructed <- inverse_rosenblatt(independent, fit)
+max(abs(simulated - reconstructed))
+```
+
+The transform follows the model's sampling order. An explicit
+`conditioning_set` requests an admissible order ending in those variables,
+which is useful when conditional quantiles must follow the same orientation as
+conditional simulation.
+
+```{r conditional-rosenblatt}
+transformed <- rosenblatt(
+  simulated,
+  fit,
+  conditioning_set = c("driver1", "driver2")
+)
+inverse_rosenblatt(
+  transformed,
+  fit,
+  conditioning_set = c("driver1", "driver2")
+)[1:3, ]
+```
+
+For discrete variables, the transform randomizes within the jump interval by
+default. See the [discrete-data guide](discrete-data.html) for the randomized
+formula, deterministic upper endpoints, and required copula layouts.
+
+## Reproducibility
+
+Conditional simulation and randomized discrete transforms use R's
+random-number state. Call `set.seed()` immediately before the operation when a
+reproducible draw is required. The original model object is never mutated by a
+conditional simulation or transform.
+
+## Related documentation
+
+- [Vine copula models and structures](vine-copula-models.html) explains the
+  structure order and selection controls used here.
+- [Marginal models](marginal-models.html) documents the transformation between
+  original observations and the copula scale.
+- The [`rvinecop()` reference](../reference/vinecop_methods.html),
+  [`rvine()` reference](../reference/vine_methods.html), and [Rosenblatt
+  reference](../reference/rosenblatt.html) give complete argument and return
+  value details.

--- a/vignettes/discrete-data.Rmd
+++ b/vignettes/discrete-data.Rmd
@@ -1,0 +1,254 @@
+---
+title: "Discrete, mixed, and zero-inflated data"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Discrete, mixed, and zero-inflated data}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(401)
+```
+
+Copula likelihoods for variables with atoms require two probabilities at every
+observation: the CDF value `F(x)` and its left limit `F(x-)`. For an
+integer-valued variable, `F(x-) = F(x - 1)`. Continuous variables satisfy
+`F(x-) = F(x)`.
+
+The high-level `vine()` interface computes these values from fitted margins.
+The copula-only `bicop()` and `vinecop()` interfaces accept them explicitly.
+
+## Discrete variables on the original scale
+
+All ordinary discrete variables are assumed to have integer support. Declare a
+numeric or integer column through `var_types = "d"`.
+
+```{r integer-data}
+n <- 100
+latent <- rnorm(n)
+x <- data.frame(
+  value = latent + rnorm(n),
+  count = rpois(n, exp(0.5 + 0.3 * latent))
+)
+
+fit <- vine(
+  x,
+  var_types = c("c", "d"),
+  copula_controls = list(family_set = "onepar")
+)
+summary(fit)$margins
+dvine(x[1:5, ], fit)
+```
+
+Explicitly discrete columns are checked for finite integer-valued observations.
+This catches accidental declarations of rounded-looking continuous data.
+
+## Ordered factors
+
+Ordered factors are discrete variables whose levels are mapped internally to
+the integer support `0, 1, ...`. Their class and levels are restored after
+simulation.
+
+```{r ordered-data}
+survey <- data.frame(
+  rating = ordered(
+    sample(c("low", "middle", "high"), n, replace = TRUE),
+    levels = c("low", "middle", "high")
+  ),
+  score = rnorm(n)
+)
+
+ordered_fit <- vine(
+  survey,
+  copula_controls = list(family_set = "indep")
+)
+ordered_draws <- rvine(5, ordered_fit)
+str(ordered_draws)
+```
+
+No `var_types` entry is needed because `ordered()` carries the declaration in
+the column class.
+
+## Zero-inflated variables
+
+`zero_inflated()` marks a continuous variable with an atom at zero. It behaves
+like a numeric vector in a data frame and survives ordinary subsetting.
+
+```{r zero-inflated}
+amount <- zero_inflated(c(rep(0, 25), rexp(75)))
+zi_data <- data.frame(amount = amount, score = rnorm(100))
+inherits(zi_data$amount, "zero_inflated")
+
+zi_fit <- vine(
+  zi_data,
+  copula_controls = list(family_set = "indep")
+)
+zi_fit$margins_controls$type
+```
+
+The atom is always located at zero. A custom zero-inflated margin must return
+the atom probability from `dmargin(0, margin)`. rvinecopulib then computes the
+left limit as
+
+```
+pmargin(0, margin) - dmargin(0, margin)
+```
+
+and uses the ordinary CDF away from zero. Alternatively, declare the type with
+`var_types = "zi"`.
+
+## Copula-scale data layouts
+
+Let `d` be the dimension and `k` the number of discrete variables. Copula
+methods accept two layouts:
+
+- **expanded:** `2d` columns, with all `F(x)` columns followed by all `F(x-)`
+  columns;
+- **compact:** `d + k` columns, with the `F(x)` block followed only by
+  left-limit columns for discrete variables, in variable order.
+
+Consider a three-dimensional model with discrete variables 1 and 3.
+
+```{r layouts}
+n <- 80
+raw <- data.frame(
+  first = rpois(n, 2),
+  middle = rnorm(n),
+  last = rpois(n, 4)
+)
+
+values <- cbind(
+  ppois(raw$first, 2),
+  pnorm(raw$middle),
+  ppois(raw$last, 4)
+)
+left_discrete <- cbind(
+  ppois(raw$first - 1, 2),
+  ppois(raw$last - 1, 4)
+)
+compact <- cbind(values, left_discrete)
+
+left_all <- cbind(
+  ppois(raw$first - 1, 2),
+  pnorm(raw$middle),
+  ppois(raw$last - 1, 4)
+)
+expanded <- cbind(values, left_all)
+
+copula_fit <- vinecop(
+  compact,
+  var_types = c("d", "c", "d"),
+  family_set = "indep"
+)
+stopifnot(isTRUE(all.equal(
+  dvinecop(compact, copula_fit),
+  dvinecop(expanded, copula_fit)
+)))
+```
+
+For a mixed bivariate model, this means three columns: the two CDF values and
+the left limit of the discrete variable. Fully discrete bivariate models need
+four columns.
+
+## What the density means
+
+`dbicop()` and `dvinecop()` return the copula density contribution defined as
+the joint density or mass divided by the marginal densities or masses. This
+definition is consistent across continuous, discrete, and mixed models.
+
+For a bivariate model, write
+\[
+u_j = F_j(x_j), \qquad u_j^- = F_j(x_j^-), \qquad
+\Delta_j = u_j - u_j^-.
+\]
+If both variables are discrete, the copula contribution is the rectangle
+probability divided by the two marginal masses:
+\[
+c^*(u_1,u_2) =
+\frac{C(u_1,u_2)-C(u_1^-,u_2)-C(u_1,u_2^-)+C(u_1^-,u_2^-)}
+     {\Delta_1\Delta_2}.
+\]
+If only the first variable is discrete, the corresponding mixed contribution
+is
+\[
+c^*(u_1,u_2) =
+\frac{\partial_2 C(u_1,u_2)-\partial_2 C(u_1^-,u_2)}{\Delta_1}.
+\]
+The continuous density `c(u1, u2)` is recovered when both jump widths vanish.
+Vine likelihoods apply these continuous, mixed, or rectangle contributions
+edge by edge to the appropriate conditional CDF values.
+
+`dvine()` multiplies that contribution by the fitted marginal densities or
+masses and therefore returns the full joint density or probability mass on the
+original scale. In general,
+\[
+f_X(x) = c^*(u,u^-)\prod_{j=1}^d f_j(x_j),
+\]
+where each `f_j` denotes a density or a probability mass as appropriate.
+
+## Simulation
+
+`rvinecop()` always returns one uniform-scale value per variable. It does not
+invent a marginal distribution for a discrete copula variable. Use `rvine()`
+when simulated values should be returned on the original scale with their
+integer, ordered, or zero-inflated margins.
+
+```{r simulation}
+copula_draws <- rvinecop(4, copula_fit)
+dim(copula_draws)
+
+original_draws <- rvine(4, ordered_fit)
+is.ordered(original_draws$rating)
+```
+
+## Rosenblatt transforms with atoms
+
+For an atom, the Rosenblatt transform is an interval rather than a single
+value. By default, `rosenblatt()` randomizes uniformly within that interval so
+the transformed variable is uniform under a correct model. Set
+`randomize_discrete = FALSE` to return the deterministic upper endpoint.
+
+More precisely, if `G_j(· | x_<j)` is the relevant conditional CDF and
+`V_j` is an independent standard uniform variable, the randomized component is
+\[
+Z_j = G_j(x_j^- \mid x_{<j})
+    + V_j\{G_j(x_j \mid x_{<j})-G_j(x_j^- \mid x_{<j})\}.
+\]
+The non-randomized version returns the upper endpoint `G_j(x_j | x_<j)`.
+
+```{r discrete-rosenblatt}
+set.seed(402)
+randomized <- rosenblatt(compact, copula_fit)
+upper_endpoint <- rosenblatt(
+  compact,
+  copula_fit,
+  randomize_discrete = FALSE
+)
+head(randomized)
+head(upper_endpoint)
+```
+
+The randomization uses R's random-number state and is reproducible with
+`set.seed()`.
+
+## Missing observations
+
+Copula fitting discards incomplete observations pair by pair, retaining the
+maximum information available for each edge. Margin implementations decide how
+to handle missing values during marginal fitting; built-in KDE margins support
+the package's established missing-data workflow. Custom `margin_family()`
+fitters should either handle missing values or fail with a useful message.
+
+## Related documentation
+
+- [Marginal models](marginal-models.html) documents how `vine()` fits and
+  evaluates integer, ordered, and zero-inflated margins.
+- [Conditional simulation and Rosenblatt
+  transforms](conditional-simulation.html) develops the multivariate transform
+  and conditional-sampling workflow.
+- The [`vine()` distribution reference](../reference/vine_methods.html) and
+  [vine-copula distribution reference](../reference/vinecop_methods.html)
+  specify the accepted evaluation layouts.

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -186,5 +186,8 @@ stopifnot(isTRUE(all.equal(draws1, draws2)))
   building blocks and family-selection controls.
 - [Vine copula models and structures](vine-copula-models.html) covers
   high-dimensional dependence modeling.
+- [Discrete data](discrete-data.html), [conditional
+  simulation](conditional-simulation.html), and [likelihood
+  inference](likelihood-inference.html) introduce advanced workflows.
 - The [function reference](../reference/index.html) lists the complete API by
   modeling task.

--- a/vignettes/likelihood-inference.Rmd
+++ b/vignettes/likelihood-inference.Rmd
@@ -1,0 +1,213 @@
+---
+title: "Scores, Hessians, and varying parameters"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Scores, Hessians, and varying parameters}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+library(rvinecopulib)
+set.seed(601)
+```
+
+rvinecopulib exposes observation-wise likelihood scores and average Hessians
+for parametric bivariate and vine copula models. These are the basic inputs for
+convergence checks, standard errors, sandwich covariance estimates, and
+gradient-based extensions.
+
+For a parameter vector `theta` and observation-wise log-likelihood
+contributions `ell_i(theta)`, rvinecopulib reports
+\[
+s_i(\theta)=\frac{\partial\ell_i(\theta)}{\partial\theta},
+\qquad
+\bar H(\theta)=\frac{1}{n}\sum_{i=1}^n
+\frac{\partial^2\ell_i(\theta)}{\partial\theta\partial\theta^\top}.
+\]
+Thus `scores()` contains the row vectors `s_i`, while `hessian()` returns
+`H-bar`.
+
+## Bivariate scores and Hessians
+
+Fit a parametric model and evaluate derivatives at its fitted parameters:
+
+```{r bicop-derivatives}
+u2 <- rbicop(250, "gaussian", 0, 0.6)
+fit2 <- bicop(u2, family_set = "gaussian")
+
+score2 <- scores(u2, fit2)
+hessian2 <- hessian(u2, fit2)
+dim(score2)
+hessian2
+colSums(score2)
+```
+
+The score matrix has one row per observation and one column per model
+parameter. At an interior maximum-likelihood estimate, its column sums should
+be close to zero. The Hessian is averaged over observations; multiply by the
+sample size when a summed log-likelihood Hessian is required.
+
+These derivatives are available for continuous parametric models. Boundary
+estimates and weakly identified parameters need the same care as in any
+likelihood analysis.
+
+## Vine parameter ordering
+
+For a vine, score columns follow `(tree, edge, parameter)` order: tree 1 from
+left to right, then tree 2, and so on; multi-parameter pair copulas contribute
+their parameters in the order shown by `get_parameters()`.
+
+```{r fit-vine}
+n <- 220
+z <- rnorm(n)
+x <- cbind(
+  z + rnorm(n),
+  0.7 * z + rnorm(n),
+  -0.5 * z + rnorm(n)
+)
+u <- pseudo_obs(x)
+fit <- vinecop(
+  u,
+  structure = dvine_structure(1:3),
+  family_set = "gaussian"
+)
+get_all_parameters(fit)
+```
+
+The number and ordering of derivative columns can be checked against the edge
+summary.
+
+```{r vine-scores}
+score <- scores(u, fit)
+hess <- hessian(u, fit)
+dim(score)
+dim(hess)
+summary(fit)
+```
+
+## Stepwise and full likelihood derivatives
+
+Vine models are usually fitted sequentially. With `step_wise = TRUE` (the
+default), each pair copula treats the pseudo-observations passed down from
+earlier trees as fixed. This is the objective optimized by the sequential
+estimator.
+
+With `step_wise = FALSE`, derivatives propagate through the complete
+h-function cascade and refer to the full joint log-likelihood.
+
+For a vine with edge set `E`, an observation contributes
+\[
+\ell_i(\theta)=\sum_{e\in E}
+\log c_e\{u_{e,1,i}(\theta_{<e}),u_{e,2,i}(\theta_{<e});\theta_e\}.
+\]
+Stepwise derivatives hold the conditional pseudo-observations `u_e` fixed.
+Full derivatives also differentiate their dependence on parameters in earlier
+trees, denoted by `theta_<e` above.
+
+```{r stepwise-full}
+stepwise_gradient <- colSums(scores(u, fit, step_wise = TRUE))
+full_gradient <- colSums(scores(u, fit, step_wise = FALSE))
+rbind(stepwise = stepwise_gradient, full = full_gradient)
+```
+
+The stepwise gradient should be close to zero at a sequential fit. The full
+gradient generally is not: a sequence of conditional maximizations is not the
+same as a joint maximum. This distinction should be stated explicitly whenever
+derivatives are used for inference.
+
+## Reuse density intermediates
+
+`dvinecop(..., keep_all = TRUE)` returns the density and the per-edge values
+computed by the h-function cascade.
+
+```{r keep-all}
+full <- dvinecop(u[1:5, ], fit, keep_all = TRUE)
+names(full)
+full$pdf
+```
+
+The triangular `pdf_edges`, `hfunc1`, and `hfunc2` entries follow the same tree
+and edge ordering as the fitted pair copulas. The `_sub` h-functions contain
+left-limit evaluations for discrete models and are empty for fully continuous
+models.
+
+## Observation-specific bivariate parameters
+
+Parametric copulas can be evaluated with a different parameter set in every
+row. This is useful when another model maps covariates to valid copula
+parameters.
+
+```{r varying-bicop}
+points <- matrix(runif(200), ncol = 2)
+rho <- seq(-0.8, 0.8, length.out = nrow(points))
+
+density <- dbicop(points, "gaussian", 0, parameters = rho)
+score_varying <- scores(points, bicop_dist("gaussian"), parameters = rho)
+hessian_varying <- hessian(
+  points,
+  bicop_dist("gaussian"),
+  parameters = rho
+)
+head(cbind(rho, density, score_varying))
+```
+
+For a one-parameter family, `parameters` may be a vector. Otherwise it must be
+a matrix with one row per observation and one column per family parameter.
+Parameters are not recycled.
+
+## Observation-specific vine parameters
+
+The vine interface takes an `n` by `p` parameter matrix, where `p` is the total
+number of pair-copula parameters and columns use the score ordering.
+
+```{r varying-vine}
+base_parameters <- unlist(get_all_parameters(fit), use.names = FALSE)
+parameter_matrix <- matrix(
+  rep(base_parameters, each = nrow(u)),
+  nrow = nrow(u)
+)
+parameter_matrix[, 1] <- seq(-0.6, 0.6, length.out = nrow(u))
+
+density_varying <- dvinecop(u, fit, parameters = parameter_matrix)
+score_varying <- scores(u, fit, parameters = parameter_matrix)
+head(density_varying)
+dim(score_varying)
+```
+
+Observation-specific vine parameters are supported for continuous,
+all-parametric models. Each row must represent a valid complete parameter
+vector. The model stored in `fit` is not modified.
+
+## From derivatives to uncertainty estimates
+
+The score and Hessian outputs deliberately provide ingredients rather than a
+single universal covariance estimator. The correct assembly depends on whether
+the estimator is stepwise or joint, whether weights or clusters are present,
+and whether robust inference is desired.
+
+For an ordinary interior bivariate MLE, the inverse negative summed Hessian is
+the familiar model-based covariance estimate. More elaborate vine inference
+should account for the sequential estimation scheme instead of treating the
+stepwise estimate as a joint maximum.
+
+In the ordinary independent-observation case, define
+\[
+A=-\bar H, \qquad B=\frac{1}{n}\sum_{i=1}^n s_i s_i^\top.
+\]
+The model-based covariance estimate is `(-n H-bar)^(-1)`, while the usual
+sandwich estimate is `A^(-1) B A^(-1) / n`. Weights, clusters, and sequential
+estimation change how these pieces should be assembled.
+
+## Related documentation
+
+- [Bivariate copula models](bivariate-copulas.html) and [vine copula models and
+  structures](vine-copula-models.html) provide the model definitions used in
+  the examples.
+- [Conditional simulation and Rosenblatt
+  transforms](conditional-simulation.html) explains the h-function cascade
+  that full derivatives propagate through.
+- The [bivariate distribution reference](../reference/bicop_methods.html) and
+  [vine-copula distribution reference](../reference/vinecop_methods.html)
+  specify derivative support and parameter shapes.

--- a/vignettes/marginal-models.Rmd
+++ b/vignettes/marginal-models.Rmd
@@ -256,3 +256,13 @@ restored <- readRDS(path)
 unlink(path)
 all.equal(dvine(x, restored), dvine(x, fit_custom))
 ```
+
+## Related documentation
+
+- [Getting started](getting-started.html) introduces the complete `vine()`
+  modeling workflow.
+- [Discrete, mixed, and zero-inflated data](discrete-data.html) derives the
+  likelihood contributions and documents copula-scale layouts.
+- The [`vine()` reference](../reference/vine.html), [margin-family
+  reference](../reference/margin_family.html), and [fitted-margin
+  protocol](../reference/margin_protocol.html) give complete API contracts.

--- a/vignettes/vine-copula-models.Rmd
+++ b/vignettes/vine-copula-models.Rmd
@@ -227,6 +227,13 @@ or construct a new `vinecop_dist()` after changing its components.
 
 - [Bivariate copula models](bivariate-copulas.html) provides the details of
   the pair-copula building blocks.
+- [Discrete, mixed, and zero-inflated data](discrete-data.html) explains the
+  copula-scale representation required when some variables have atoms.
+- [Conditional simulation and Rosenblatt
+  transforms](conditional-simulation.html) describes conditioning-aware
+  structures and sampling orders.
+- [Scores, Hessians, and varying parameters](likelihood-inference.html)
+  explains edge parameter ordering and stepwise versus full derivatives.
 - The [`vinecop()` reference](../reference/vinecop.html) lists all fitting and
   selection arguments; the [structure reference](../reference/rvine_structure.html)
   gives the formal matrix validity conditions.


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by #331 and #332. Do not merge this documentation stack yet.**
> After both PRs merge into `dev`, rebase the margin stack (#334–#338) and
> documentation stack (#339–#341), confirm version `1.0.0.1.0`, and rerun the
> rendered documentation checks.

Top documentation layer in stack #336; based on #340.

## Summary

- document discrete, mixed, ordered, and zero-inflated data, including the
  rectangle and mixed copula likelihood contributions;
- document conditional simulation and continuous and randomized-discrete
  Rosenblatt transforms;
- document observation-wise scores, average Hessians, stepwise versus full
  derivatives, varying parameters, and model-based and sandwich covariance;
- add cross-links among the advanced guides, core guides, margins guide, and
  API reference.

## Validation

- all seven package vignettes render successfully;
- all internal links across the 47-page local pkgdown preview resolve;
- `pkgdown::check_pkgdown(".")`;
- `git diff --check`.

The full source build was stopped during backend compilation after 90 seconds;
it had not reported an error. The vignette renders above completed separately.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
