### PR TITLE
Reject invalid candidates during margin selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -114,6 +114,9 @@ for the complete backend changes.
   warnings, reject fitted supports that exclude observations, and detect failed
   forked workers and malformed margin core counts early.
 
+* Reject margin candidates with non-finite fitted log-likelihoods without
+  aborting selection when another valid candidate is available (#350).
+
 * Make inverse Rosenblatt transforms thread-safe and custom tree criteria safe
   under multithreaded fitting.
 

--- a/R/margins.R
+++ b/R/margins.R
@@ -1029,9 +1029,13 @@ select_margin <- function(
   problems <- character()
   fits <- lapply(candidates, function(candidate) {
     family_name <- margin_info(candidate)$family_name
-    fit <- tryCatch(
+    tryCatch(
       withCallingHandlers(
-        fit_margin(candidate, x, weights = weights, type = type),
+        {
+          fit <- fit_margin(candidate, x, weights = weights, type = type)
+          validate_margin_candidate(fit, x, family_name, type)
+          fit
+        },
         warning = function(condition) {
           problems <<- c(
             problems,
@@ -1056,11 +1060,6 @@ select_margin <- function(
         NULL
       }
     )
-    if (is.null(fit)) {
-      return(NULL)
-    }
-    validate_margin_candidate(fit, x, family_name, type)
-    fit
   })
   fitted <- !vapply(fits, is.null, logical(1))
   fits <- fits[fitted]

--- a/tests/testthat/test_margins.R
+++ b/tests/testthat/test_margins.R
@@ -473,8 +473,8 @@ test_that("selection handles incompatibility, candidate failures, and bad fits",
     select_margin(rnorm(20), list(malformed), "c", numeric(), "aic", 1),
     "fitted-margin protocol"
   )
-  expect_error(
-    select_margin(
+  expect_warning(
+    selected <- select_margin(
       rnorm(20),
       list(malformed, good),
       "c",
@@ -482,8 +482,9 @@ test_that("selection handles incompatibility, candidate failures, and bad fits",
       "aic",
       1
     ),
-    "fitted-margin protocol"
+    "malformed failed.*fitted-margin protocol"
   )
+  expect_identical(margin_info(selected)$family_name, "good")
 
   missing_loglik <- scored_margin_family("missing-loglik", NA_real_, 1)
   expect_error(
@@ -557,6 +558,30 @@ test_that("selection handles incompatibility, candidate failures, and bad fits",
     select_margin(rnorm(20), list(good), "d", numeric(), "aic", 1),
     "no candidate margin"
   )
+})
+
+test_that("selection rejects non-finite fitted log-likelihoods", {
+  skip_if_not_installed("univariateML")
+  x <- c(0, seq(0.1, 2, length.out = 30))
+  rayleigh <- univariateML_family("rayleigh")
+  good <- scored_margin_family("good", -100, 1)
+
+  expect_error(
+    select_margin(x, list(rayleigh), "c", numeric(), "aic", 1),
+    "could not fit.*rayleigh failed.*loglik.*finite or NA"
+  )
+  expect_warning(
+    selected <- select_margin(
+      x,
+      list(rayleigh, good),
+      "c",
+      numeric(),
+      "aic",
+      1
+    ),
+    "rayleigh failed.*loglik.*finite or NA"
+  )
+  expect_identical(margin_info(selected)$family_name, "good")
 })
 
 test_that("every family receives weights and decides how to handle them", {


### PR DESCRIPTION
## Summary

- Validate each fitted margin inside the same failure boundary as fitting.
- Reject candidates with non-finite log-likelihoods while allowing valid alternatives to continue through selection.
- Preserve an informative aggregated error when every candidate is invalid.
- Update malformed-candidate expectations and add a Rayleigh boundary regression.
- Record the fix in NEWS.

## Validation

- Margin tests: 135 passed, no warnings or skips.
- Full test suite: 1,193 passed; four pre-existing finite-parameter-count warnings.
- Direct vine(..., family_set = "all") boundary reproduction completes successfully.
- air format . and git diff --check pass.

Closes #350